### PR TITLE
Use correct plugin ID in integration tests.

### DIFF
--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -12,7 +12,7 @@ buildscript {
     }
 }
 plugins {
-    id 'static-analysis'
+    id 'com.novoda.static-analysis'
 }
 repositories {
     jcenter()

--- a/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
@@ -5,7 +5,7 @@ final class TestJavaProject extends TestProject {
     private static final Closure<String> TEMPLATE = { TestProject project ->
         """
 plugins {
-    id 'static-analysis'
+    id 'com.novoda.static-analysis'
 }
 repositories {
     jcenter()


### PR DESCRIPTION
The plugin ID has been changed to [`com.novoda.static-analysis`](https://github.com/novoda/gradle-static-analysis-plugin/commit/dc177468723c9fe92c948dfea7ab8919dc06f03b) but the integration tests were still using `static-analysis` instead.