### PR TITLE
Use correct artifact name for plugin

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.novoda.bintray-release'
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
-    artifactId = 'static-analysis-plugin'
+    artifactId = 'gradle-static-analysis-plugin'
     publishVersion = '0.1'
     website = 'https://github.com/novoda/spikes/tree/master/static-analysis-plugin'
 }


### PR DESCRIPTION
The artifact name specified in the `publish` configuration is not following the accepted internal convention. Maven coordinates for the artifact should be
```
com.novoda:gradle-static-analysis-plugin:0.1
```