### PR TITLE
Update the website in the publish configuration

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -4,6 +4,6 @@ publish {
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
     publishVersion = '0.1'
-    website = 'https://github.com/novoda/spikes/tree/master/static-analysis-plugin'
+    website = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 


### PR DESCRIPTION
The plugin has moved out of `novoda/spikes`, but the publish configuration was still pointing to that repo.

> Hopefully this is the last change before the first release to Bintray 😅 