### PR TITLE
Don't override default effort and report level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Build output
 build
+out
 
 # Gradle files
 .gradle/

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -59,8 +59,6 @@ class FindbugsConfigurator {
     }
 
     private void configureTask(Project project, FindBugs findBugs, Task evaluateViolations, Violations violations, List<String> excludes) {
-        findBugs.effort = 'max'
-        findBugs.reportLevel = 'low'
         findBugs.ignoreFailures = true
         findBugs.reports.xml.enabled = true
         findBugs.reports.html.enabled = false

--- a/plugin/src/test/fixtures/findbugs/low/LowPriorityViolator.java
+++ b/plugin/src/test/fixtures/findbugs/low/LowPriorityViolator.java
@@ -1,5 +1,6 @@
 public class LowPriorityViolator {
-    public boolean equals(Object o) {
-        return this == o;
+    public void foo() {
+        int a = 1;
+        a++;
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -43,6 +43,22 @@ class FindbugsIntegrationTest {
     }
 
     @Test
+    public void shouldDetectMoreWarningsWhenEffortIsMaxAndReportLevelIsLow() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withFindbugs('findbugs { effort = \'max\' \n reportLevel = \'low\'}')
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 2)
+        assertThat(result.logs).containsFindbugsViolations(0, 3,
+                result.buildFile('reports/findbugs/debug.html'))
+    }
+
+    @Test
     public void shouldFailBuildWhenFindbugsErrorsOverTheThreshold() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('debug', SOURCES_WITH_HIGH_VIOLATION)

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -50,7 +50,7 @@ class FindbugsIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 1
                 }''')
-                .withFindbugs('findbugs { effort = \'max\' \n reportLevel = \'low\'}')
+                .withFindbugs("findbugs { effort = 'max' \n reportLevel = 'low'}")
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(0, 2)

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -31,13 +31,13 @@ class FindbugsIntegrationTest {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
                 .withPenalty('''{
-                    maxErrors = 10
-                    maxWarnings = 10
+                    maxErrors = 0
+                    maxWarnings = 1
                 }''')
                 .withFindbugs('findbugs {}')
-                .build('check')
+                .buildAndFail('check')
 
-        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsLimitExceeded(0, 1)
         assertThat(result.logs).containsFindbugsViolations(0, 2,
                 result.buildFile('reports/findbugs/debug.html'))
     }


### PR DESCRIPTION
> Tracked in JIRA by [PT-312](https://novoda.atlassian.net/browse/PT-312)

### Scope of the PR

The effort and report level of FindBugs were enforced by us, overriding the defaults, but this is something that a user might not want. Leave the defaults in place, and let the user choose if he wants other values.

### Considerations/Implementation Details

Really straight forward, just remove setting the values in the task configurator. 

Since by default FindBugs is not that restrictive anymore,  `LowPriorityViolator.java` was updated to contain a violation with priority 3 that will get picked up with the defaults.

#### Testing

Updated (fix) test that said that it should fail build when threshold is passed

Added a test to showcase how one can change the effort and report level