### PR TITLE
Configurators refactoring

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,33 +1,37 @@
 package com.novoda.staticanalysis
 
+import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.Violations
 import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
 import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator
 import com.novoda.staticanalysis.internal.pmd.PmdConfigurator
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 class StaticAnalysisPlugin implements Plugin<Project> {
+
     @Override
     void apply(Project project) {
-        StaticAnalysisExtension extension = project.extensions.create('staticAnalysis', StaticAnalysisExtension)
-
-        NamedDomainObjectContainer<Violations> allViolations = project.container(Violations)
-        Task evaluateViolations = project.tasks.create('evaluateViolations', EvaluateViolationsTask) { task ->
-            task.penalty = extension.penalty
-            task.allViolations = allViolations
-        }
-        [
-                new CheckstyleConfigurator(project, allViolations.create('Checkstyle'), evaluateViolations),
-                new PmdConfigurator(project, allViolations.create('PMD'), evaluateViolations),
-                new FindbugsConfigurator(project, allViolations.create('Findbugs'), evaluateViolations)
-        ].each { configurator -> configurator.execute() }
-
+        EvaluateViolationsTask evaluateViolations = createEvaluateViolationsTask(project)
+        createConfigurators(project, evaluateViolations).each { configurator -> configurator.execute() }
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations
         }
     }
 
+    private EvaluateViolationsTask createEvaluateViolationsTask(Project project) {
+        StaticAnalysisExtension extension = project.extensions.create('staticAnalysis', StaticAnalysisExtension)
+        project.tasks.create('evaluateViolations', EvaluateViolationsTask) { task ->
+            task.penaltyExtension = extension.penalty
+            task.violationsContainer = project.container(Violations)
+        }
+    }
+
+    private List<CodeQualityConfigurator> createConfigurators(Project project, EvaluateViolationsTask evaluateViolations) {
+        [
+                new CheckstyleConfigurator(project, evaluateViolations),
+                new PmdConfigurator(project, evaluateViolations),
+                new FindbugsConfigurator(project, evaluateViolations)
+        ]
+    }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -1,0 +1,65 @@
+package com.novoda.staticanalysis.internal
+
+import com.novoda.staticanalysis.EvaluateViolationsTask
+import com.novoda.staticanalysis.StaticAnalysisExtension
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.api.tasks.SourceTask
+
+abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQualityExtension> {
+
+    protected final Project project
+    protected final Violations violations
+    protected final EvaluateViolationsTask evaluateViolations
+    protected final List<String> excludes = []
+
+    protected CodeQualityConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
+        this.project = project
+        this.violations = violations
+        this.evaluateViolations = evaluateViolations
+    }
+
+    void execute() {
+        project.extensions.findByType(StaticAnalysisExtension).ext."$toolName" = { Closure config ->
+            project.apply plugin: toolPlugin
+            project.extensions.findByType(extensionClass).with {
+                defaultConfiguration.execute(it)
+                ext.exclude = { String pattern -> excludes.add(pattern) }
+                config.delegate = it
+                config()
+            }
+            project.afterEvaluate {
+                boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
+                boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
+                if (isAndroidApp || isAndroidLib) {
+                    configureAndroid(isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants)
+                }
+                project.tasks.withType(taskClass) { task -> configureTask(task) }
+            }
+        }
+    }
+
+    protected abstract String getToolName()
+
+    protected Object getToolPlugin() {
+        toolName
+    }
+
+    protected abstract Class<E> getExtensionClass()
+
+    protected Action<E> getDefaultConfiguration() {
+        new Action<E>() {
+            void execute(E ignored) {
+                // no op
+            }
+        }
+    }
+
+    protected abstract void configureAndroid(Object variants)
+
+    protected abstract Class<T> getTaskClass()
+
+    protected abstract void configureTask(T task)
+
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -3,7 +3,6 @@ package com.novoda.staticanalysis.internal.checkstyle
 import com.novoda.staticanalysis.EvaluateViolationsTask
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.internal.Violations
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -13,8 +12,8 @@ import org.gradle.internal.logging.ConsoleRenderer
 
 class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, CheckstyleExtension> {
 
-    CheckstyleConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolationsTask) {
-        super(project, violations, evaluateViolationsTask)
+    CheckstyleConfigurator(Project project, EvaluateViolationsTask evaluateViolationsTask) {
+        super(project, evaluateViolationsTask.maybeCreate('Checkstyle'), evaluateViolationsTask)
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -1,50 +1,54 @@
 package com.novoda.staticanalysis.internal.findbugs
 
-import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.EvaluateViolationsTask
+import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.Violations
+import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
 import org.gradle.internal.logging.ConsoleRenderer
 
-class FindbugsConfigurator {
+class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {
 
-    void configure(Project project, Violations violations, StaticAnalysisExtension extension, Task evaluateViolations) {
-        extension.ext.findbugs = { Closure config ->
-            project.apply plugin: QuietFindbugsPlugin
-            List<String> excludes = []
-            configureExtension(project.extensions.findByType(FindBugsExtension), excludes, config)
-            project.afterEvaluate {
-                configureAndroidIfNeeded(project)
-                project.tasks.withType(FindBugs) { FindBugs findBugs ->
-                    configureTask(project, findBugs, evaluateViolations, violations, excludes)
-                }
+    FindbugsConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
+        super(project, violations, evaluateViolations)
+    }
+
+    @Override
+    protected String getToolName() {
+        'findbugs'
+    }
+
+    @Override
+    protected Object getToolPlugin() {
+        QuietFindbugsPlugin
+    }
+
+    @Override
+    protected Class<FindBugsExtension> getExtensionClass() {
+        FindBugsExtension
+    }
+
+    @Override
+    protected Class<FindBugs> getTaskClass() {
+        FindBugs
+    }
+
+    @Override
+    protected Action<FindBugsExtension> getDefaultConfiguration() {
+        new Action<FindBugsExtension>() {
+            @Override
+            void execute(FindBugsExtension findBugsExtension) {
+                findBugsExtension.toolVersion = '3.0.1'
             }
         }
     }
 
-    private void configureExtension(FindBugsExtension extension, List<String> excludes, Closure config) {
-        extension.with {
-            toolVersion = '3.0.1'
-            ext.exclude = { String filter -> excludes.add(filter) }
-            config.delegate = it
-            config()
-        }
-    }
-
-    private void configureAndroidIfNeeded(Project project) {
-        boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
-        boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
-        if (isAndroidApp || isAndroidLib) {
-            def variants = isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants
-            configureAndroid(project, variants)
-        }
-    }
-
-    private void configureAndroid(Project project, Object variants) {
+    @Override
+    protected void configureAndroid(Object variants) {
         variants.all { variant ->
             FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
             task.with {
@@ -58,7 +62,8 @@ class FindbugsConfigurator {
         }
     }
 
-    private void configureTask(Project project, FindBugs findBugs, Task evaluateViolations, Violations violations, List<String> excludes) {
+    @Override
+    protected void configureTask(FindBugs findBugs) {
         findBugs.ignoreFailures = true
         findBugs.reports.xml.enabled = true
         findBugs.reports.html.enabled = false
@@ -66,12 +71,18 @@ class FindbugsConfigurator {
         File xmlReportFile = findBugs.reports.xml.destination
         File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')
         findBugs.doLast {
-            evaluateReports(xmlReportFile, htmlReportFile, violations)
+            evaluateReports(xmlReportFile, htmlReportFile)
         }
-        createHtmlReportTask(project, findBugs, xmlReportFile, htmlReportFile, evaluateViolations)
+        createHtmlReportTask(findBugs, xmlReportFile, htmlReportFile)
     }
 
-    private GenerateHtmlReport createHtmlReportTask(Project project, FindBugs findBugs, File xmlReportFile, File htmlReportFile, evaluateViolations) {
+    private void evaluateReports(File xmlReportFile, File htmlReportFile) {
+        def evaluator = new FinbugsViolationsEvaluator(xmlReportFile)
+        String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile)
+        violations.addViolations(evaluator.errorsCount(), evaluator.warningsCount(), reportUrl)
+    }
+
+    private GenerateHtmlReport createHtmlReportTask(FindBugs findBugs, File xmlReportFile, File htmlReportFile) {
         project.tasks.create("generate${findBugs.name.capitalize()}HtmlReport", GenerateHtmlReport) { GenerateHtmlReport generateHtmlReport ->
             generateHtmlReport.xmlReportFile = xmlReportFile
             generateHtmlReport.htmlReportFile = htmlReportFile
@@ -79,12 +90,6 @@ class FindbugsConfigurator {
             generateHtmlReport.dependsOn findBugs
             evaluateViolations.dependsOn generateHtmlReport
         }
-    }
-
-    private void evaluateReports(File xmlReportFile, File htmlReportFile, Violations violations) {
-        def evaluator = new FinbugsViolationsEvaluator(xmlReportFile)
-        String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile)
-        violations.addViolations(evaluator.errorsCount(), evaluator.warningsCount(), reportUrl)
     }
 
     static class GenerateHtmlReport extends JavaExec {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -91,26 +91,4 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         }
     }
 
-    static class GenerateHtmlReport extends JavaExec {
-        @Input
-        File xmlReportFile
-
-        @Input
-        File htmlReportFile
-
-        @Override
-        void exec() {
-            if (xmlReportFile != null && xmlReportFile.exists()) {
-                main = 'edu.umd.cs.findbugs.PrintingBugReporter'
-                standardOutput = createHtmlReportOutput()
-                args '-html', xmlReportFile
-                super.exec()
-            }
-        }
-
-        private FileOutputStream createHtmlReportOutput() {
-            new FileOutputStream(htmlReportFile)
-        }
-    }
-
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -2,7 +2,6 @@ package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.EvaluateViolationsTask
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.FindBugs
@@ -13,8 +12,8 @@ import org.gradle.internal.logging.ConsoleRenderer
 
 class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {
 
-    FindbugsConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
-        super(project, violations, evaluateViolations)
+    FindbugsConfigurator(Project project, EvaluateViolationsTask evaluateViolations) {
+        super(project, evaluateViolations.maybeCreate('Findbugs'), evaluateViolations)
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -6,8 +6,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.JavaExec
 import org.gradle.internal.logging.ConsoleRenderer
 
 class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/GenerateHtmlReport.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/GenerateHtmlReport.groovy
@@ -1,0 +1,23 @@
+package com.novoda.staticanalysis.internal.findbugs
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.JavaExec
+
+class GenerateHtmlReport extends JavaExec {
+
+    @Input
+    File xmlReportFile
+
+    @Input
+    File htmlReportFile
+
+    @Override
+    void exec() {
+        if (xmlReportFile != null && xmlReportFile.exists()) {
+            main = 'edu.umd.cs.findbugs.PrintingBugReporter'
+            standardOutput = new FileOutputStream(htmlReportFile)
+            args '-html', xmlReportFile
+            super.exec()
+        }
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -12,8 +12,8 @@ import org.gradle.internal.logging.ConsoleRenderer
 
 class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
-    PmdConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
-        super(project, violations, evaluateViolations)
+    PmdConfigurator(Project project, EvaluateViolationsTask evaluateViolations) {
+        super(project, evaluateViolations.maybeCreate('PMD'), evaluateViolations)
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -1,52 +1,49 @@
 package com.novoda.staticanalysis.internal.pmd
 
+import com.novoda.staticanalysis.EvaluateViolationsTask
+import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.internal.Violations
+import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
 import org.gradle.internal.logging.ConsoleRenderer
 
-class PmdConfigurator {
+class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
-    void configure(Project project, Violations violations, StaticAnalysisExtension extension, Task evaluateViolations) {
-        extension.ext.pmd = { Closure config ->
-            project.apply plugin: 'pmd'
-            List<String> excludes = []
-            configureExtension(project.extensions.findByType(PmdExtension), excludes, config)
-            project.afterEvaluate {
-                configureAndroidIfNeeded(project)
-                project.tasks.withType(Pmd) { pmd ->
-                    configureTask(pmd, violations, excludes)
-                    evaluateViolations.dependsOn pmd
-                }
+    PmdConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
+        super(project, violations, evaluateViolations)
+    }
+
+    @Override
+    protected String getToolName() {
+        'pmd'
+    }
+
+    @Override
+    protected Class<PmdExtension> getExtensionClass() {
+        PmdExtension
+    }
+
+    @Override
+    protected Class<Pmd> getTaskClass() {
+        Pmd
+    }
+
+    @Override
+    protected Action<PmdExtension> getDefaultConfiguration() {
+        new Action<PmdExtension>() {
+            @Override
+            void execute(PmdExtension pmdExtension) {
+                pmdExtension.toolVersion = '5.5.1'
+                pmdExtension.rulePriority = 5
             }
         }
     }
 
-    private void configureAndroidIfNeeded(Project project) {
-        boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
-        boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
-        if (isAndroidApp || isAndroidLib) {
-            def variants = isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants
-            configureAndroid(project, variants)
-        }
-    }
-
-    private Object configureExtension(PmdExtension extension, List<String> excludes, Closure config) {
-        extension.with {
-            toolVersion = '5.5.1'
-            ext.exclude = { String filter ->
-                excludes.add(filter)
-            }
-            config.delegate = it
-            config()
-        }
-    }
-
-    private void configureAndroid(Project project, Object variants) {
+    @Override
+    protected void configureAndroid(Object variants) {
         project.with {
             android.sourceSets.all { sourceSet ->
                 def sourceDirs = sourceSet.java.srcDirs
@@ -66,10 +63,10 @@ class PmdConfigurator {
         }
     }
 
-    private void configureTask(Pmd pmd, Violations violations, List<String> excludes) {
+    @Override
+    protected void configureTask(Pmd pmd) {
         pmd.group = 'verification'
         pmd.ignoreFailures = true
-        pmd.rulePriority = 5
         pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
         pmd.exclude(excludes)
         pmd.doLast {
@@ -77,9 +74,10 @@ class PmdConfigurator {
             File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')
             evaluateReports(xmlReportFile, htmlReportFile, violations)
         }
+        evaluateViolations.dependsOn pmd
     }
 
-    private void evaluateReports(File xmlReportFile, File htmlReportFile, Violations violations) {
+    private static void evaluateReports(File xmlReportFile, File htmlReportFile, Violations violations) {
         PmdViolationsEvaluator evaluator = new PmdViolationsEvaluator(xmlReportFile)
         int errors = 0, warnings = 0
         evaluator.collectViolations().each { PmdViolationsEvaluator.PmdViolation violation ->
@@ -92,5 +90,4 @@ class PmdConfigurator {
         String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
         violations.addViolations(errors, warnings, reportUrl)
     }
-
 }


### PR DESCRIPTION
> Tracked in JIRA by [PT-315](https://novoda.atlassian.net/browse/PT-315)

### Scope of the PR

The API of the `*Configurator` classes has grown quite organically, but it's also clear they share some structure. Time to play the [_Rule of three_](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) and refactor out common traits in a super class.

### Considerations/Implementation Details

- Introduced `CodeQualityConfigurator` as super class for all the configurators provided at the moment
- Rearranged code in `StaticAnalysisPlugin` and its delegates to declutter setup step
- Pulled out `GenerateHtmlReport` task out of `FindBugsConfigurator`

#### Testing
Refactoring only. All the tests are still passing 🎉 


> **Note for the reviewers:** I'm aware the diff is a little bit noisy, but the changes in the `*Configurator` classes are similar and hopefully it should be easy to see how the common parts have popped in `CodeQualityConfigurator`. Using the split view maybe would help in this case.