### PR TITLE
Correcting README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ staticAnalysis {
         configFile project.file('path/to/modules.xml')
     }
     pmd {
-        ruleSetFiles = project.file('path/to/rules.xml')
+        ruleSetFiles = project.files('path/to/rules.xml')
     }
     findbugs {}
 }


### PR DESCRIPTION
`PMD.ruleSetFiles` is a `FileCollection` which means we should be using `Project.files`