### PR TITLE
PT-420: Honour Android variants in Chesktyle and PMD

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -35,6 +35,8 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
                 if (isAndroidApp || isAndroidLib) {
                     configureAndroid(isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants)
+                    configureAndroid(project.android.testVariants)
+                    configureAndroid(project.android.unitTestVariants)
                 }
                 project.tasks.withType(taskClass) { task -> configureTask(task) }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -44,19 +44,23 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     @Override
     protected void configureAndroid(Object variants) {
         project.with {
-            android.sourceSets.all { sourceSet ->
-                def sourceDirs = sourceSet.java.srcDirs
-                def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
-                if (notEmptyDirs.empty) {
-                    return
-                }
-                Checkstyle checkstyle = tasks.create("checkstyle${sourceSet.name.capitalize()}", Checkstyle)
-                checkstyle.with {
-                    description = "Run Checkstyle analysis for ${sourceSet.name} classes"
-                    source = sourceSet.java.srcDirs
-                    classpath = files("$buildDir/intermediates/classes/")
-                }
-                variants.all { variant ->
+            variants.all { variant ->
+                variant.sourceSets.each { sourceSet ->
+
+                    def taskName = "checkstyle${sourceSet.name.capitalize()}"
+                    Checkstyle checkstyle = tasks.findByName(taskName)
+                    if (checkstyle == null) {
+                        checkstyle = tasks.create(taskName, Checkstyle)
+                        def sourceDirs = sourceSet.java.srcDirs
+                        def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
+                        if (!notEmptyDirs.empty) {
+                            checkstyle.with {
+                                description = "Run Checkstyle analysis for ${sourceSet.name} classes"
+                                source = sourceSet.java.srcDirs
+                                classpath = files("$buildDir/intermediates/classes/")
+                            }
+                        }
+                    }
                     checkstyle.mustRunAfter variant.javaCompile
                 }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -46,7 +46,6 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
         project.with {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->
-
                     def taskName = "checkstyle${sourceSet.name.capitalize()}"
                     Checkstyle checkstyle = tasks.findByName(taskName)
                     if (checkstyle == null) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -45,18 +45,21 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     @Override
     protected void configureAndroid(Object variants) {
         project.with {
-            android.sourceSets.all { sourceSet ->
-                def sourceDirs = sourceSet.java.srcDirs
-                def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
-                if (notEmptyDirs.empty) {
-                    return
-                }
-                Pmd pmd = tasks.create("pmd${sourceSet.name.capitalize()}", Pmd)
-                pmd.with {
-                    description = "Run PMD analysis for ${sourceSet.name} classes"
-                    source = sourceSet.java.srcDirs
-                }
-                variants.all { variant ->
+            variants.all { variant ->
+                variant.sourceSets.each { sourceSet ->
+                    def taskName = "pmd${sourceSet.name.capitalize()}"
+                    Pmd pmd = tasks.findByName(taskName)
+                    if (pmd == null) {
+                        pmd = tasks.create(taskName, Pmd)
+                        def sourceDirs = sourceSet.java.srcDirs
+                        def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
+                        if (!notEmptyDirs.empty) {
+                            pmd.with {
+                                description = "Run PMD analysis for ${sourceSet.name} classes"
+                                source = sourceSet.java.srcDirs
+                            }
+                        }
+                    }
                     pmd.mustRunAfter variant.javaCompile
                 }
             }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
@@ -1,0 +1,174 @@
+package com.novoda.staticanalysis.internal.checkstyle
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestAndroidProject
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+import static com.novoda.test.LogsSubject.assertThat
+
+class CheckstyleAndroidVariantIntegrationTest {
+
+    private static final String DEFAULT_CONFIG = "configFile new File('${Fixtures.Checkstyle.MODULES.path}')"
+
+    @Rule
+    public final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInMainApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 1)
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                result.buildFile('reports/checkstyle/main.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenCheckstyleViolationsBelowThresholdInMainApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                result.buildFile('reports/checkstyle/main.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInUnitTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsCheckstyleViolations(1, 1,
+                result.buildFile('reports/checkstyle/main.html'),
+                result.buildFile('reports/checkstyle/test.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInAndroidTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('androidTest', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsCheckstyleViolations(1, 1,
+                result.buildFile('reports/checkstyle/main.html'),
+                result.buildFile('reports/checkstyle/androidTest.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                    }
+                ''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsCheckstyleViolations(1, 1,
+                result.buildFile('reports/checkstyle/main.html'),
+                result.buildFile('reports/checkstyle/demo.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInActiveProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        if(variant.name.contains('full')) {
+                            variant.setIgnore(true);
+                        }
+                    }
+                ''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsCheckstyleViolations(1, 1,
+                result.buildFile('reports/checkstyle/main.html'),
+                result.buildFile('reports/checkstyle/demo.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenCheckstyleViolationsOverThresholdInIgnoredVariants() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        variant.setIgnore(true);
+                    }
+                ''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .build('check')
+
+        assertThat(result.logs).doesNotContainCheckstyleViolations()
+    }
+
+    private static String checkstyle(String configFile, String... configs) {
+        """checkstyle {
+            ${configFile}
+            ${configs.join('\n\t\t\t')}
+        }"""
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
@@ -11,7 +11,7 @@ import static com.novoda.test.LogsSubject.assertThat
 
 class CheckstyleAndroidVariantIntegrationTest {
 
-    private static final String DEFAULT_CONFIG = "configFile new File('${Fixtures.Checkstyle.MODULES.path}')"
+    private static final String DEFAULT_CONFIG = "checkstyle { configFile new File('${Fixtures.Checkstyle.MODULES.path}') }"
 
     @Rule
     public final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
@@ -24,13 +24,14 @@ class CheckstyleAndroidVariantIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 0
                 }''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(0, 1)
         assertThat(result.logs).containsCheckstyleViolations(0, 1,
                 result.buildFile('reports/checkstyle/main.html'))
     }
+
 
     @Test
     public void shouldNotFailBuildWhenCheckstyleViolationsBelowThresholdInMainApplicationVariant() {
@@ -40,7 +41,7 @@ class CheckstyleAndroidVariantIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 1
                 }''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .build('check')
 
         assertThat(result.logs).doesNotContainLimitExceeded()
@@ -57,7 +58,7 @@ class CheckstyleAndroidVariantIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 1
                 }''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(1, 0)
@@ -75,7 +76,7 @@ class CheckstyleAndroidVariantIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 1
                 }''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(1, 0)
@@ -99,7 +100,7 @@ class CheckstyleAndroidVariantIntegrationTest {
                         demo
                     }
                 ''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(1, 0)
@@ -130,7 +131,7 @@ class CheckstyleAndroidVariantIntegrationTest {
                         }
                     }
                 ''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(1, 0)
@@ -159,16 +160,10 @@ class CheckstyleAndroidVariantIntegrationTest {
                         variant.setIgnore(true);
                     }
                 ''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .withCheckstyle(DEFAULT_CONFIG)
                 .build('check')
 
         assertThat(result.logs).doesNotContainCheckstyleViolations()
     }
 
-    private static String checkstyle(String configFile, String... configs) {
-        """checkstyle {
-            ${configFile}
-            ${configs.join('\n\t\t\t')}
-        }"""
-    }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdAndroidVariantIntegrationTest.groovy
@@ -1,0 +1,168 @@
+package com.novoda.staticanalysis.internal.pmd
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestAndroidProject
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+import static com.novoda.test.LogsSubject.assertThat
+
+class PmdAndroidVariantIntegrationTest {
+
+    private static final String DEFAULT_RULES = "pmd { ruleSetFiles = project.files('${Fixtures.Pmd.RULES.path}') }"
+
+    @Rule
+    public final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
+
+    @Test
+    public void shouldFailBuildWhenPmdViolationsOverThresholdInMainApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .withPmd(DEFAULT_RULES)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 1)
+        assertThat(result.logs).containsPmdViolations(0, 1,
+                result.buildFile('reports/pmd/main.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenPmdViolationsBelowThresholdInMainApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withPmd(DEFAULT_RULES)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsPmdViolations(0, 1,
+                result.buildFile('reports/pmd/main.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenPmdViolationsOverThresholdInUnitTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withSourceSet('test', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withPmd(DEFAULT_RULES)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsPmdViolations(1, 1,
+                result.buildFile('reports/pmd/main.html'),
+                result.buildFile('reports/pmd/test.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenPmdViolationsOverThresholdInAndroidTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withSourceSet('androidTest', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withPmd(DEFAULT_RULES)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsPmdViolations(1, 1,
+                result.buildFile('reports/pmd/main.html'),
+                result.buildFile('reports/pmd/androidTest.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenPmdViolationsOverThresholdInProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withSourceSet('demo', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('full', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                    }
+                ''')
+                .withPmd(DEFAULT_RULES)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsPmdViolations(1, 1,
+                result.buildFile('reports/pmd/main.html'),
+                result.buildFile('reports/pmd/demo.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenPmdViolationsOverThresholdInActiveProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withSourceSet('demo', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('full', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        if(variant.name.contains('full')) {
+                            variant.setIgnore(true);
+                        }
+                    }
+                ''')
+                .withPmd(DEFAULT_RULES)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsPmdViolations(1, 1,
+                result.buildFile('reports/pmd/main.html'),
+                result.buildFile('reports/pmd/demo.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenPmdViolationsOverThresholdInIgnoredVariants() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_3_VIOLATION)
+                .withSourceSet('demo', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('full', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        variant.setIgnore(true);
+                    }
+                ''')
+                .withPmd(DEFAULT_RULES)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainCheckstyleViolations()
+    }
+
+}

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -1,7 +1,7 @@
 package com.novoda.test
 
-class TestAndroidProject extends TestProject {
-    private static final Closure<String> TEMPLATE = { TestProject project ->
+class TestAndroidProject extends TestProject<TestAndroidProject> {
+    private static final Closure<String> TEMPLATE = { TestAndroidProject project ->
         """
 buildscript {
     repositories {

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -31,10 +31,13 @@ android {
     sourceSets {
         ${formatSourceSets(project)}
     }
+    ${project.additionalAndroidConfig}
 }
 ${formatExtension(project)}
 """
     }
+
+    private String additionalAndroidConfig = ''
 
     TestAndroidProject() {
         super(TEMPLATE)
@@ -61,5 +64,10 @@ ${formatExtension(project)}
     @Override
     List<String> defaultArguments() {
         ['-x', 'lint'] + super.defaultArguments()
+    }
+
+    TestAndroidProject withAdditionalAndroidConfig(String additionalAndroidConfig) {
+        this.additionalAndroidConfig = additionalAndroidConfig
+        return this
     }
 }

--- a/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
@@ -1,6 +1,6 @@
 package com.novoda.test
 
-final class TestJavaProject extends TestProject {
+final class TestJavaProject extends TestProject<TestJavaProject> {
 
     private static final Closure<String> TEMPLATE = { TestProject project ->
         """

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -3,7 +3,7 @@ package com.novoda.test
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 
-abstract class TestProject {
+abstract class TestProject<T extends TestProject> {
     private static final Closure<String> EXTENSION_TEMPLATE = { TestProject project ->
         """
 staticAnalysis {
@@ -46,12 +46,12 @@ staticAnalysis {
         Collections.emptyList()
     }
 
-    public TestProject withFile(File source, String path) {
+    public T withFile(File source, String path) {
         write(source.text, path)
         return this
     }
 
-    public TestProject withFile(String text, String path) {
+    public T withFile(String text, String path) {
         write(text, path)
         return this
     }
@@ -62,27 +62,27 @@ staticAnalysis {
         file.text = text
     }
 
-    public TestProject withSourceSet(String sourceSet, File... srcDirs) {
+    public T withSourceSet(String sourceSet, File... srcDirs) {
         sourceSets[sourceSet] = srcDirs
         return this
     }
 
-    public TestProject withPenalty(String penalty) {
+    public T withPenalty(String penalty) {
         this.penalty = "penalty $penalty"
         return this
     }
 
-    public TestProject withCheckstyle(String checkstyle) {
+    public T withCheckstyle(String checkstyle) {
         this.checkstyle = checkstyle
         return this
     }
 
-    public TestProject withPmd(String pmd) {
+    public T withPmd(String pmd) {
         this.pmd = pmd
         return this
     }
 
-    public TestProject withFindbugs(String findbugs) {
+    public T withFindbugs(String findbugs) {
         this.findbugs = findbugs
         return this
     }

--- a/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
@@ -4,17 +4,17 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-final class TestProjectRule implements TestRule {
+final class TestProjectRule<T extends TestProject> implements TestRule {
 
-    private final Closure<TestProject> projectFactory
+    private final Closure<T> projectFactory
     private final Closure<String> sourceSetNameFactory
-    private TestProject project
+    private T project
 
-    static TestProjectRule forJavaProject() {
+    static TestProjectRule<TestJavaProject> forJavaProject() {
         new TestProjectRule({ new TestJavaProject() }, { String name -> "project.sourceSets.$name" })
     }
 
-    static TestProjectRule forAndroidProject() {
+    static TestProjectRule<TestAndroidProject> forAndroidProject() {
         new TestProjectRule({ new TestAndroidProject() }, { String name -> "project.android.sourceSets.$name" })
     }
 
@@ -23,7 +23,7 @@ final class TestProjectRule implements TestRule {
         this.sourceSetNameFactory = sourceSetNameFactory
     }
 
-    public TestProject newProject() {
+    public T newProject() {
         project = projectFactory.call()
         return project
     }


### PR DESCRIPTION
> Tracked by [PT-240](https://novoda.atlassian.net/browse/PT-420)

## Scope of the PR

During the integration of this plugin in one of our running projects @xrigau noticed that all Checkstyle and PMD tasks were run even tho some of the variants were disabled. The root issue is in the way we are creating such tasks, where only the source sets are evaluated without actually considering the variants. 

## Considerations and implementation
- Introduced generics to correctly enforce type for the `TestProject` builders
- Used `ApplicationVariant`/`TestVariant`/`UnitTestVariant` to determine which source sets should be inspected by Checkstyle and PMD.
- If the same source set is used in multiple variants (eg: `main`) we ensure only one `CheckstyleMain`/`PmdMain` task is created

### Test(s) added 

Added integration tests checking behaviour of Checkstyle and PMD wrt Android variants. Scenarios include:
- violations in test variants (android and unit test)
- no product flavors
- multiple product flavors
- manually disabled variants (via `variantFileter`)

### Paired with 
@ 👻 