### PR TITLE
Release v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 0.3 *(27/01/2017)*
+--------------------------
+
+- Honour project variants when creating tasks for Checkstyle and PMD ([PR#16](https://github.com/novoda/gradle-static-analysis-plugin/pull/16))
+
 Version 0.2 *(14/11/2016)*
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.2'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.3'
     }
 }
 ```

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -3,7 +3,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
-    publishVersion = '0.2'
+    publishVersion = '0.3'
     website = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #16.

## Considerations and implementation
- Updated necessary publishing configuration
- Updated `README` to be compliant with internal convention
- Updated `CHANGELOG` to track changes in releases
