### PR TITLE
PT-427: Make Findbugs to honour the exclude filters

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -41,7 +41,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 project.tasks.withType(taskClass) { task ->
                     task.group = 'verification'
                     filter.applyTo(task)
-                    configureTask(task)
+                    configureReportEvaluation(task)
                 }
             }
         }
@@ -67,6 +67,6 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
 
     protected abstract Class<T> getTaskClass()
 
-    protected abstract void configureTask(T task)
+    protected abstract void configureReportEvaluation(T task)
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -38,7 +38,11 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                     configureAndroid(project.android.testVariants)
                     configureAndroid(project.android.unitTestVariants)
                 }
-                project.tasks.withType(taskClass) { task -> configureTask(task) }
+                project.tasks.withType(taskClass) { task ->
+                    task.group = 'verification'
+                    filter.applyTo(task)
+                    configureTask(task)
+                }
             }
         }
     }
@@ -63,9 +67,6 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
 
     protected abstract Class<T> getTaskClass()
 
-    protected void configureTask(T task) {
-        task.group = 'verification'
-        filter.applyTo(task)
-    }
+    protected abstract void configureTask(T task)
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -12,13 +12,13 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     protected final Project project
     protected final Violations violations
     protected final EvaluateViolationsTask evaluateViolations
-    protected final SourceFilter filter
+    protected final SourceFilter sourceFilter
 
     protected CodeQualityConfigurator(Project project, Violations violations, EvaluateViolationsTask evaluateViolations) {
         this.project = project
         this.violations = violations
         this.evaluateViolations = evaluateViolations
-        this.filter = new SourceFilter(project)
+        this.sourceFilter = new SourceFilter(project)
     }
 
     void execute() {
@@ -26,7 +26,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
             project.apply plugin: toolPlugin
             project.extensions.findByType(extensionClass).with {
                 defaultConfiguration.execute(it)
-                ext.exclude = { Object rule -> filter.exclude(rule) }
+                ext.exclude = { Object rule -> sourceFilter.exclude(rule) }
                 config.delegate = it
                 config()
             }
@@ -40,7 +40,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 }
                 project.tasks.withType(taskClass) { task ->
                     task.group = 'verification'
-                    filter.applyTo(task)
+                    sourceFilter.applyTo(task)
                     configureReportEvaluation(task)
                 }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -34,9 +34,9 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
                 boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
                 if (isAndroidApp || isAndroidLib) {
-                    configureAndroid(isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants)
-                    configureAndroid(project.android.testVariants)
-                    configureAndroid(project.android.unitTestVariants)
+                    configureAndroidProject(isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants)
+                    configureAndroidProject(project.android.testVariants)
+                    configureAndroidProject(project.android.unitTestVariants)
                 }
                 project.tasks.withType(taskClass) { task ->
                     task.group = 'verification'
@@ -63,7 +63,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
         }
     }
 
-    protected abstract void configureAndroid(Object variants)
+    protected abstract void configureAndroidProject(Object variants)
 
     protected abstract Class<T> getTaskClass()
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -37,10 +37,11 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                     configureAndroidProject(isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants)
                     configureAndroidProject(project.android.testVariants)
                     configureAndroidProject(project.android.unitTestVariants)
+                } else {
+                    configureJavaProject()
                 }
                 project.tasks.withType(taskClass) { task ->
                     task.group = 'verification'
-                    sourceFilter.applyTo(task)
                     configureReportEvaluation(task)
                 }
             }
@@ -64,6 +65,10 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     }
 
     protected abstract void configureAndroidProject(Object variants)
+
+    protected void configureJavaProject() {
+        project.tasks.withType(taskClass) { task -> sourceFilter.applyTo(task) }
+    }
 
     protected abstract Class<T> getTaskClass()
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -67,7 +67,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     }
 
     @Override
-    protected void configureTask(Checkstyle checkstyle) {
+    protected void configureReportEvaluation(Checkstyle checkstyle) {
         checkstyle.showViolations = false
         checkstyle.ignoreFailures = true
         checkstyle.metaClass.getLogger = { QuietLogger.INSTANCE }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -42,7 +42,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     }
 
     @Override
-    protected void configureAndroid(Object variants) {
+    protected void configureAndroidProject(Object variants) {
         project.with {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -68,7 +68,6 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
 
     @Override
     protected void configureTask(Checkstyle checkstyle) {
-        super.configureTask(checkstyle)
         checkstyle.showViolations = false
         checkstyle.ignoreFailures = true
         checkstyle.metaClass.getLogger = { QuietLogger.INSTANCE }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -56,6 +56,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
                             classpath = files("$buildDir/intermediates/classes/")
                         }
                     }
+                    sourceFilter.applyTo(task)
                     task.mustRunAfter variant.javaCompile
                 }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -47,16 +47,16 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->
                     def taskName = "checkstyle${sourceSet.name.capitalize()}"
-                    Checkstyle checkstyle = tasks.findByName(taskName)
-                    if (checkstyle == null) {
-                        checkstyle = tasks.create(taskName, Checkstyle)
-                        checkstyle.with {
+                    Checkstyle task = tasks.findByName(taskName)
+                    if (task == null) {
+                        task = tasks.create(taskName, Checkstyle)
+                        task.with {
                             description = "Run Checkstyle analysis for ${sourceSet.name} classes"
                             source = sourceSet.java.srcDirs
                             classpath = files("$buildDir/intermediates/classes/")
                         }
                     }
-                    checkstyle.mustRunAfter variant.javaCompile
+                    task.mustRunAfter variant.javaCompile
                 }
             }
         }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -50,14 +50,10 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
                     Checkstyle checkstyle = tasks.findByName(taskName)
                     if (checkstyle == null) {
                         checkstyle = tasks.create(taskName, Checkstyle)
-                        def sourceDirs = sourceSet.java.srcDirs
-                        def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
-                        if (!notEmptyDirs.empty) {
-                            checkstyle.with {
-                                description = "Run Checkstyle analysis for ${sourceSet.name} classes"
-                                source = sourceSet.java.srcDirs
-                                classpath = files("$buildDir/intermediates/classes/")
-                            }
+                        checkstyle.with {
+                            description = "Run Checkstyle analysis for ${sourceSet.name} classes"
+                            source = sourceSet.java.srcDirs
+                            classpath = files("$buildDir/intermediates/classes/")
                         }
                     }
                     checkstyle.mustRunAfter variant.javaCompile

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -4,9 +4,14 @@ import com.novoda.staticanalysis.EvaluateViolationsTask
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
+import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.logging.ConsoleRenderer
+
+import java.nio.file.Path
 
 class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {
 
@@ -48,15 +53,65 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     protected void configureAndroidProject(Object variants) {
         variants.all { variant ->
             FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
+            List<File> androidSourceDirs = variant.sourceSets.collect { it.javaDirectories }.flatten()
             task.with {
                 description = "Run FindBugs analysis for ${variant.name} classes"
-                source = variant.sourceSets.java.srcDirs.collect { it.path }.flatten()
-                classes = project.fileTree(variant.javaCompile.destinationDir)
+                source = androidSourceDirs
                 classpath = variant.javaCompile.classpath
             }
             sourceFilter.applyTo(task)
+            task.conventionMapping.map("classes", {
+                List<String> includes = createIncludesPatternsFrom(task.source, androidSourceDirs)
+                project.fileTree(variant.javaCompile.destinationDir).include(includes)
+            }.memoize());
             task.dependsOn variant.javaCompile
         }
+    }
+
+    @Override
+    protected void configureJavaProject() {
+        project.sourceSets.each { SourceSet sourceSet ->
+            String taskName = sourceSet.getTaskName(toolName, null)
+            FindBugs task = project.tasks.findByName(taskName)
+            if (task != null) {
+                sourceFilter.applyTo(task)
+                task.conventionMapping.map("classes", {
+                    List<File> sourceDirs = sourceSet.allJava.srcDirs.findAll { it.exists() }.toList()
+                    List<String> includes = createIncludesPatternsFrom(task.source, sourceDirs)
+                    createClassesTreeFrom(sourceSet).include(includes)
+                }.memoize());
+            }
+        }
+    }
+
+    private static List<String> createIncludesPatternsFrom(FileCollection sourceFiles, List<File> sourceDirs) {
+        List<Path> includedSourceFiles = sourceFiles.matching { '**/*.java' }.files.collect { it.toPath() }
+        createIncludePatterns(includedSourceFiles, sourceDirs.collect { it.toPath() })
+    }
+
+    private static List<String> createIncludePatterns(List<Path> includedSourceFiles, List<Path> sourceDirs) {
+        createRelativePaths(includedSourceFiles, sourceDirs)
+                .collect { Path relativePath -> (relativePath as String) - '.java' + '*' }
+                .each { println "[include: $it]" }
+    }
+
+    private static List<Path> createRelativePaths(List<Path> includedSourceFiles, List<Path> sourceDirs) {
+        includedSourceFiles.collect { Path sourceFile ->
+            sourceDirs
+                    .findAll { Path sourceDir -> sourceFile.startsWith(sourceDir) }
+                    .collect { Path sourceDir -> sourceDir.relativize(sourceFile) }
+        }
+        .flatten()
+    }
+
+    /**
+     * The simple "classes = sourceSet.output" may lead to non-existing resources directory
+     * being passed to FindBugs Ant task, resulting in an error
+     * */
+    private ConfigurableFileTree createClassesTreeFrom(SourceSet sourceSet) {
+        project.fileTree(sourceSet.output.classesDir, {
+            it.builtBy(sourceSet.output)
+        })
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -61,7 +61,6 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     @Override
     protected void configureTask(FindBugs findBugs) {
-        super.configureTask(findBugs)
         findBugs.ignoreFailures = true
         findBugs.reports.xml.enabled = true
         findBugs.reports.html.enabled = false

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -61,7 +61,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             }
             sourceFilter.applyTo(task)
             task.conventionMapping.map("classes", {
-                List<String> includes = createIncludesPatternsFrom(task.source, androidSourceDirs)
+                List<String> includes = createIncludePatterns(task.source, androidSourceDirs)
                 project.fileTree(variant.javaCompile.destinationDir).include(includes)
             }.memoize());
             task.dependsOn variant.javaCompile
@@ -77,20 +77,17 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
                 sourceFilter.applyTo(task)
                 task.conventionMapping.map("classes", {
                     List<File> sourceDirs = sourceSet.allJava.srcDirs.findAll { it.exists() }.toList()
-                    List<String> includes = createIncludesPatternsFrom(task.source, sourceDirs)
+                    List<String> includes = createIncludePatterns(task.source, sourceDirs)
                     createClassesTreeFrom(sourceSet).include(includes)
                 }.memoize());
             }
         }
     }
 
-    private static List<String> createIncludesPatternsFrom(FileCollection sourceFiles, List<File> sourceDirs) {
-        List<Path> includedSourceFiles = sourceFiles.matching { '**/*.java' }.files.collect { it.toPath() }
-        createIncludePatterns(includedSourceFiles, sourceDirs.collect { it.toPath() })
-    }
-
-    private static List<String> createIncludePatterns(List<Path> includedSourceFiles, List<Path> sourceDirs) {
-        createRelativePaths(includedSourceFiles, sourceDirs)
+    private static List<String> createIncludePatterns(FileCollection sourceFiles, List<File> sourceDirs) {
+        List<Path> includedSourceFilesPaths = sourceFiles.matching { '**/*.java' }.files.collect { it.toPath() }
+        List<Path> sourceDirsPaths = sourceDirs.collect { it.toPath() }
+        createRelativePaths(includedSourceFilesPaths, sourceDirsPaths)
                 .collect { Path relativePath -> (relativePath as String) - '.java' + '*' }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -49,13 +49,13 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         variants.all { variant ->
             FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
             task.with {
-                group = "verification"
                 description = "Run FindBugs analysis for ${variant.name} classes"
                 source = variant.sourceSets.java.srcDirs.collect { it.path }.flatten()
                 classes = project.fileTree(variant.javaCompile.destinationDir)
                 classpath = variant.javaCompile.classpath
-                dependsOn variant.javaCompile
             }
+            sourceFilter.applyTo(task)
+            task.dependsOn variant.javaCompile
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -60,7 +60,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     @Override
-    protected void configureTask(FindBugs findBugs) {
+    protected void configureReportEvaluation(FindBugs findBugs) {
         findBugs.ignoreFailures = true
         findBugs.reports.xml.enabled = true
         findBugs.reports.html.enabled = false

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -92,7 +92,6 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     private static List<String> createIncludePatterns(List<Path> includedSourceFiles, List<Path> sourceDirs) {
         createRelativePaths(includedSourceFiles, sourceDirs)
                 .collect { Path relativePath -> (relativePath as String) - '.java' + '*' }
-                .each { println "[include: $it]" }
     }
 
     private static List<Path> createRelativePaths(List<Path> includedSourceFiles, List<Path> sourceDirs) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -45,7 +45,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     @Override
-    protected void configureAndroid(Object variants) {
+    protected void configureAndroidProject(Object variants) {
         variants.all { variant ->
             FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
             task.with {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -43,7 +43,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     }
 
     @Override
-    protected void configureAndroid(Object variants) {
+    protected void configureAndroidProject(Object variants) {
         project.with {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -67,7 +67,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     }
 
     @Override
-    protected void configureTask(Pmd pmd) {
+    protected void configureReportEvaluation(Pmd pmd) {
         pmd.ignoreFailures = true
         pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
         pmd.doLast {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -51,13 +51,9 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
                     Pmd pmd = tasks.findByName(taskName)
                     if (pmd == null) {
                         pmd = tasks.create(taskName, Pmd)
-                        def sourceDirs = sourceSet.java.srcDirs
-                        def notEmptyDirs = sourceDirs.findAll { it.list()?.length > 0 }
-                        if (!notEmptyDirs.empty) {
-                            pmd.with {
-                                description = "Run PMD analysis for ${sourceSet.name} classes"
-                                source = sourceSet.java.srcDirs
-                            }
+                        pmd.with {
+                            description = "Run PMD analysis for ${sourceSet.name} classes"
+                            source = sourceSet.java.srcDirs
                         }
                     }
                     pmd.mustRunAfter variant.javaCompile

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -48,15 +48,15 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->
                     def taskName = "pmd${sourceSet.name.capitalize()}"
-                    Pmd pmd = tasks.findByName(taskName)
-                    if (pmd == null) {
-                        pmd = tasks.create(taskName, Pmd)
-                        pmd.with {
+                    Pmd task = tasks.findByName(taskName)
+                    if (task == null) {
+                        task = tasks.create(taskName, Pmd)
+                        task.with {
                             description = "Run PMD analysis for ${sourceSet.name} classes"
                             source = sourceSet.java.srcDirs
                         }
                     }
-                    pmd.mustRunAfter variant.javaCompile
+                    task.mustRunAfter variant.javaCompile
                 }
             }
         }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -56,6 +56,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
                             source = sourceSet.java.srcDirs
                         }
                     }
+                    sourceFilter.applyTo(task)
                     task.mustRunAfter variant.javaCompile
                 }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -68,7 +68,6 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
     @Override
     protected void configureTask(Pmd pmd) {
-        super.configureTask(pmd)
         pmd.ignoreFailures = true
         pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
         pmd.doLast {

--- a/plugin/src/test/fixtures/findbugs/high/HighPriorityViolator.java
+++ b/plugin/src/test/fixtures/findbugs/high/HighPriorityViolator.java
@@ -1,9 +1,0 @@
-public class HighPriorityViolator {
-
-    public void impossibleCast() {
-        final Object doubleValue = Double.valueOf(1.0);
-        final Long value = (Long) doubleValue;
-        System.out.println("   - " + value);
-    }
-
-}

--- a/plugin/src/test/fixtures/findbugs/high/com/novoda/test/HighPriorityViolator.java
+++ b/plugin/src/test/fixtures/findbugs/high/com/novoda/test/HighPriorityViolator.java
@@ -1,0 +1,15 @@
+package com.novoda.test;
+
+public class HighPriorityViolator {
+
+    public static class Internal {
+
+        public void impossibleCast() {
+            final Object doubleValue = Double.valueOf(1.0);
+            final Long value = (Long) doubleValue;
+            System.out.println("   - " + value);
+        }
+
+    }
+
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -140,7 +140,7 @@ class FindbugsIntegrationTest {
                     maxErrors = 0
                     maxWarnings = 10
                 }''')
-                .withFindbugs('findbugs { exclude "HighPriorityViolator.java" }')
+                .withFindbugs('findbugs { exclude "com/novoda/test/HighPriorityViolator.java" }')
                 .build('check')
 
         assertThat(result.logs).doesNotContainLimitExceeded()

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -134,8 +134,8 @@ class FindbugsIntegrationTest {
     @Test
     public void shouldNotFailBuildWhenFindbugsConfiguredToExcludePattern() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
-                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
                 .withPenalty('''{
                     maxErrors = 0
                     maxWarnings = 10


### PR DESCRIPTION
> Tracked by [PT-427](https://novoda.atlassian.net/browse/PT-427)

## Scope of the PR

Findbugs is currently ignoring the exclude filters specified as part of the plugin configuration.
The issue is related to the fact the tool is working against class files while the exclude filters are applied only to sources. To solve the problem we need to filter out the classes produced from source files excluded in the config.

## Considerations and implementation
We decided to create include patterns for the `classes` property of the `Findbugs` task evaluating the filtered set of source files specified via `source` (and after the `exclude` filters from the plugin extension have been applied), for instance:

- original source file: `com.novoda.test.HighPriorityViolator.java`
- generated include pattern: `com/novoda/test/HighPriorityViolator*`

Note that the `*` at the end will allow to catch inner classes as well.
Incidentally the internals of `*Configurator` classes have been refactored to expose a clean configuration point for Java projects via `configureJavaProject()`.

### Test(s) added 

`FindbugsIntegrationTest` is now testing the case where we provide an `exclude` filter to skip one specific file from the sources as opposed to the entire source set as before. The source file used in the test is also now using a proper package and contains an inner class, to make the test more significative.
