### PR TITLE
Release v0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ local.properties
 
 # Generated files
 gen/
+
+# Properties files
+secrets.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 0.3.1 *(08/02/2017)*
+--------------------------
+
+- Honour exclude filters in Findbugs tasks ([PR#20](https://github.com/novoda/gradle-static-analysis-plugin/pull/20))
+
 Version 0.3 *(27/01/2017)*
 --------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,23 @@
 Change Log
 ==========
 
-Version 0.3.1 *(08/02/2017)*
+[Version 0.3.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3.1)
 --------------------------
 
 - Honour exclude filters in Findbugs tasks ([PR#20](https://github.com/novoda/gradle-static-analysis-plugin/pull/20))
 
-Version 0.3 *(27/01/2017)*
+[Version 0.3](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3)
 --------------------------
 
 - Honour project variants when creating tasks for Checkstyle and PMD ([PR#16](https://github.com/novoda/gradle-static-analysis-plugin/pull/16))
 
-Version 0.2 *(14/11/2016)*
+[Version 0.2](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.2)
 --------------------------
 
 - Improved `exclude` rules support ([PR#8](https://github.com/novoda/gradle-static-analysis-plugin/pull/8))
 - Enforced default effort and report level for Findbugs ([PR#6](https://github.com/novoda/gradle-static-analysis-plugin/pull/6))
 
-Version 0.1 *(09/11/2016)*
+[Version 0.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.1)
 --------------------------
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.3'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.3.1'
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ subprojects {
         }
         dependencies {
             classpath 'com.novoda:bintray-release:0.4.0'
+            classpath 'com.novoda:gradle-build-properties-plugin:0.2'
+            classpath 'org.ajoberstar:gradle-git:1.6.0'
         }
     }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,9 +1,102 @@
+version = '0.3.1'
+String tag = "v$project.version"
+groovydoc.docTitle = 'Static Analysis Plugin'
+
 apply plugin: 'com.novoda.bintray-release'
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
-    publishVersion = '0.3'
+    publishVersion = project.version
     website = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 
+apply plugin: 'com.novoda.build-properties'
+buildProperties {
+    secrets {
+        file(rootProject.file('secrets.properties'), '''
+This file should contain:
+- git.username: the username used to push to the repo
+- git.password: the password used to push to the repo
+		''')
+    }
+}
+
+apply plugin: 'org.ajoberstar.grgit'
+apply plugin: 'org.ajoberstar.github-pages'
+
+githubPages {
+    commitMessage = "Deploy groovydoc for release $tag"
+    pages {
+        from groovydoc.destinationDir
+        into "docs/${project.version}"
+    }
+}
+
+task prepareGhCredentials {
+    description = 'Prepare GitHub credentials'
+    group = 'release'
+    doLast {
+        System.properties['org.ajoberstar.grgit.auth.username'] = buildProperties.secrets['git.username'].string
+        System.properties['org.ajoberstar.grgit.auth.password'] = buildProperties.secrets['git.password'].string
+    }
+}
+
+prepareGhPages.dependsOn groovydoc
+publishGhPages.dependsOn prepareGhCredentials
+
+task prepareRelease {
+    description = 'Prepare changelog and tag for release'
+    group = 'release'
+    dependsOn prepareGhPages, prepareGhCredentials
+    doLast {
+        String changelog = extractChangelog()
+        grgit.tag.add {
+            name = tag
+            message = "Release $tag\n\n$changelog"
+        }
+    }
+}
+
+String extractChangelog() {
+    String fullChangelog = rootProject.file('CHANGELOG.md').text
+    def latestChangelog = (fullChangelog =~ /Version ${project.version}.*\n-*([\s\S]*?)Version.*\n-*/)
+    if (latestChangelog.size() > 0) {
+        return latestChangelog[0][1].trim()
+    }
+
+    def firstChangelog = (fullChangelog =~ /Version ${project.version}.*\n-*([\s\S]*)/)
+    if (firstChangelog.size() > 0) {
+        return firstChangelog[0][1].trim()
+    }
+    throw new GradleException("No changelog found for version $project.version")
+}
+
+task publishArtifact {
+    description = "Publish artifact for plugin version: $tag"
+    group = 'release'
+    project.afterEvaluate { dependsOn bintrayUpload }
+    mustRunAfter prepareRelease
+}
+
+task publishGroovydoc {
+    description = "Deploy groovydoc for plugin version: $tag"
+    group = 'release'
+    dependsOn publishGhPages
+    mustRunAfter publishArtifact
+}
+
+task publishRelease {
+    description = "Publish release for plugin version: $tag"
+    group = 'release'
+    if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
+        dependsOn prepareRelease, publishArtifact, publishGroovydoc
+        doLast {
+            grgit.push {
+                tags = true
+            }
+        }
+    } else {
+        dependsOn publishArtifact
+    }
+}


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #20.

## Considerations and implementation
- Updated `README` to be compliant with internal convention
- Updated `CHANGELOG` to track changes in releases
- Added a simple gradle script that helps the automation of the release, including:
  - Publishing of plugin artifact to Bintray
  - Creation and upload of groovydocs to github pages
  - Creation of tag

