### PR TITLE
PT-434: Better classes filtering for Findbugs tasks

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -62,10 +62,14 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             sourceFilter.applyTo(task)
             task.conventionMapping.map("classes", {
                 List<String> includes = createIncludePatterns(task.source, androidSourceDirs)
-                project.fileTree(variant.javaCompile.destinationDir).include(includes)
-            }.memoize());
+                getAndroidClasses(variant, includes)
+            });
             task.dependsOn variant.javaCompile
         }
+    }
+
+    private FileCollection getAndroidClasses(Object variant, List<String> includes) {
+        includes.isEmpty() ? project.files() : project.fileTree(variant.javaCompile.destinationDir).include(includes)
     }
 
     @Override
@@ -78,8 +82,8 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
                 task.conventionMapping.map("classes", {
                     List<File> sourceDirs = sourceSet.allJava.srcDirs.findAll { it.exists() }.toList()
                     List<String> includes = createIncludePatterns(task.source, sourceDirs)
-                    createClassesTreeFrom(sourceSet).include(includes)
-                }.memoize());
+                    getJavaClasses(sourceSet, includes)
+                });
             }
         }
     }
@@ -98,6 +102,10 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
                     .collect { Path sourceDir -> sourceDir.relativize(sourceFile) }
         }
         .flatten()
+    }
+
+    private FileCollection getJavaClasses(SourceSet sourceSet, List<String> includes) {
+        includes.isEmpty() ? project.files() : createClassesTreeFrom(sourceSet).include(includes)
     }
 
     /**

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -143,6 +143,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             generateHtmlReport.htmlReportFile = htmlReportFile
             generateHtmlReport.classpath = findBugs.findbugsClasspath
             generateHtmlReport.dependsOn findBugs
+            generateHtmlReport.onlyIf { xmlReportFile?.exists() }
             evaluateViolations.dependsOn generateHtmlReport
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/GenerateHtmlReport.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/GenerateHtmlReport.groovy
@@ -13,11 +13,9 @@ class GenerateHtmlReport extends JavaExec {
 
     @Override
     void exec() {
-        if (xmlReportFile != null && xmlReportFile.exists()) {
-            main = 'edu.umd.cs.findbugs.PrintingBugReporter'
-            standardOutput = new FileOutputStream(htmlReportFile)
-            args '-html', xmlReportFile
-            super.exec()
-        }
+        main = 'edu.umd.cs.findbugs.PrintingBugReporter'
+        standardOutput = new FileOutputStream(htmlReportFile)
+        args '-html', xmlReportFile
+        super.exec()
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -323,23 +323,8 @@ class FindbugsIntegrationTest {
     }
 
     /**
-     * <p>While integrating the plugin in one of our projects we realised that Findbugs was analysing a source folder
-     * even though an {@code exclude} rule was provided for it.
-     * After quite some investigation we realised that the issue is related to the way we create {@code include} patterns
-     * from the filtered collection in {@code source}: given a {@code Findbugs} task we peek into the filtered set
-     * of source files and for each of them we create an {@code include} rule for the related class(es).
-     * Let's assume {@code source} contains {@code foo/Bar.java}; then the plugin will produce
-     * {@code foo/Bar*} as include pattern to allow the {@code Bar.class} (and its inner classes) to be included in
-     * the analysis.</p>
-     *
-     * <p>When the {@code source} is empty (eg: all the source files have been filtered out) no include pattern can be
-     * generated, therefore the collection of classes won't be filtered at all. This sometimes is not a problem
-     * because the analysis task is skipped anyway ({@code source} property is marked as {@code @SkipWhenEmpty}), but this
-     * seems not enough to cover all cases. We decided then to enforce an empty collection for {@code classes} when
-     * an empty {@code source} is found.</p>
-     *
-     * </p>This method provides a snippet that will create a custom task checking whther this constraint is valid
-     * in a specific project. </p>
+     * The custom task created in the snippet below will check whether {@code Findbugs} tasks with
+     * empty {@code source} will have empty {@code classes} too. </p>
      */
     private String addCheckFindbugsClassesTask() {
         '''

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -246,7 +246,9 @@ class FindbugsIntegrationTest {
                 .build('check')
 
         Truth.assertThat(result.outcome(':findbugsDebug')).isEqualTo(TaskOutcome.SUCCESS)
+        Truth.assertThat(result.outcome(':generateFindbugsDebugHtmlReport')).isEqualTo(TaskOutcome.SUCCESS)
         Truth.assertThat(result.outcome(':findbugsTest')).isEqualTo(TaskOutcome.UP_TO_DATE)
+        Truth.assertThat(result.outcome(':generateFindbugsTestHtmlReport')).isEqualTo(TaskOutcome.SKIPPED)
     }
 
     @Test
@@ -269,9 +271,13 @@ class FindbugsIntegrationTest {
                 .build('check')
 
         Truth.assertThat(result.outcome(':findbugsDebugAndroidTest')).isEqualTo(TaskOutcome.UP_TO_DATE)
+        Truth.assertThat(result.outcome(':generateFindbugsDebugAndroidTestHtmlReport')).isEqualTo(TaskOutcome.SKIPPED)
         Truth.assertThat(result.outcome(':findbugsDebug')).isEqualTo(TaskOutcome.SUCCESS)
+        Truth.assertThat(result.outcome(':generateFindbugsDebugHtmlReport')).isEqualTo(TaskOutcome.SUCCESS)
         Truth.assertThat(result.outcome(':findbugsDebugUnitTest')).isEqualTo(TaskOutcome.UP_TO_DATE)
+        Truth.assertThat(result.outcome(':generateFindbugsDebugUnitTestHtmlReport')).isEqualTo(TaskOutcome.SKIPPED)
         Truth.assertThat(result.outcome(':findbugsRelease')).isEqualTo(TaskOutcome.UP_TO_DATE)
+        Truth.assertThat(result.outcome(':generateFindbugsReleaseHtmlReport')).isEqualTo(TaskOutcome.SKIPPED)
     }
 
     @Test

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -2,6 +2,9 @@ package com.novoda.test
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+import javax.annotation.Nullable
 
 abstract class TestProject<T extends TestProject> {
     private static final Closure<String> EXTENSION_TEMPLATE = { TestProject project ->
@@ -140,6 +143,11 @@ ${project.additionalConfiguration}
 
         File buildFile(String path) {
             new File(buildDir, path)
+        }
+
+        @Nullable
+        TaskOutcome outcome(String taskPath) {
+            buildResult.task(taskPath).outcome
         }
 
         public static class Logs {

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -12,12 +12,14 @@ staticAnalysis {
     ${(project.pmd ?: '').replace('        ', '    ')}
     ${(project.findbugs ?: '').replace('        ', '    ')}
 }
+${project.additionalConfiguration}
 """
     }
 
     private final File projectDir
     private final GradleRunner gradleRunner
     private final Closure<String> template
+    String additionalConfiguration = ''
     Map<String, List<File>> sourceSets = [main: []]
     String penalty
     String checkstyle
@@ -84,6 +86,11 @@ staticAnalysis {
 
     public T withFindbugs(String findbugs) {
         this.findbugs = findbugs
+        return this
+    }
+
+    public T withAdditionalConfiguration(String additionalConfiguration) {
+        this.additionalConfiguration = additionalConfiguration
         return this
     }
 

--- a/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
@@ -27,4 +27,8 @@ class TestProjectSubject extends Subject<TestProjectSubject, TestProject> {
     public void isAndroidProject() {
         check().that(actual()).isInstanceOf(TestAndroidProject)
     }
+
+    public void isJavaProject() {
+        check().that(actual()).isInstanceOf(TestJavaProject)
+    }
 }


### PR DESCRIPTION
> Tracked by [PT-434](https://novoda.atlassian.net/browse/PT-434)

## Scope of the PR

While integrating the plugin in one of our projects we realised that Findbugs was analysing a source folder even though an exclude rule was provided for it.

## Considerations and implementation
After quite some investigation we realised that the issue is related to the way* we create include patterns from the filtered collection in `source`. When the source is empty (eg: all the source files have been filtered out) no include pattern can be generated, therefore the collection of classes won't be filtered at all. This sometimes is not a problem because the analysis task is skipped anyway (`source` property is marked as [`@SkipWhenEmpty`](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/SourceTask.html#getSource())), but this doesn't seem enough to cover all cases.
We decided then to enforce an empty collection for `classes` when an empty collection is found in `source`.

Incidentally the task generating html reports for findbugs is now skipped when the related analysis has not run.

### Test(s) added 

`FindbugsIntegrationTest` now contains few more tests to check:
- which `:findbug*` task has been executed/skipped
- whether an empty `classes` property is provided to each `findbugs*` task with an empty `source`

------

> (*) Given a `Findbugs` task we evaluate the filtered set of source files and for each of them we create an include rule for the related class(es).
>Let's assume source contains `foo/Bar.java`; we expect the plugin will produce `foo/Bar*` as include pattern to allow the `Bar.class` (and its inner classes) to be included in
the analysis.