### PR TITLE
PT-442: Customise reports base url in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It's possible to specify a custom renderer for the report urls in the logs via t
 staticAnalysis {
     ...
     logs {
-        baseReportUrl "http://ci.mycompany.com/job/myproject/ws/app/build/reports"
+        reportBaseUrl "http://ci.mycompany.com/job/myproject/ws/app/build/reports"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ the relevant html reports, for instance:
     - file:///foo/project/build/reports/pmd/main4.html
 ```
 
+It's possible to specify a custom renderer for the report urls in the logs via the `logs` extension. This can be useful in CI
+ environments, where the local paths are not reachable directly. For instance the snippet below will replace the base url with
+ one of your choice:
+```gradle
+staticAnalysis {
+    ...
+    logs {
+        baseReportUrl "http://ci.mycompany.com/job/myproject/ws/app/build/reports"
+    }
+}
+```
+so that in the logs you will see the report urls printed as
+```
+> Checkstyle rule violations were found (0 errors, 1 warnings). See the reports at:
+- http://ci.mycompany.com/job/myproject/ws/app/build/reports/checkstyle/main.html
+```
+More info on the topic can be found in the [`LogsExtension`](https://github.com/novoda/gradle-static-analysis-plugin/blob/master/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy)
+groovydoc.
+
 #### Out-of-the-box support for Android projects
 Android projects use a gradle model that is not compatible with the Java one, supported by the built-in static analysis tools plugins.
 Applying `gradle-static-analysis-plugin` to your Android project will make sure all the necessary tasks are created and correctly configured

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile gradleApi()
 
     testCompile gradleTestKit()
+    testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.30'
     testCompile 'com.google.guava:guava:19.0'
     testCompile 'com.google.code.findbugs:jsr305:3.0.0'

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -1,15 +1,15 @@
 package com.novoda.staticanalysis
 
 import com.novoda.staticanalysis.internal.Violations
-import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.logging.ConsoleRenderer
 
-class EvaluateViolationsTask extends DefaultTask {
+class EvaluateViolationsTask extends ConventionTask {
     private PenaltyExtension penaltyExtension
     private NamedDomainObjectContainer<Violations> violationsContainer
+    private ReportUrlRenderer reportUrlRenderer
 
     EvaluateViolationsTask() {
         group = 'verification'
@@ -26,6 +26,10 @@ class EvaluateViolationsTask extends DefaultTask {
 
     Violations maybeCreate(String name) {
         violationsContainer.maybeCreate(name)
+    }
+
+    ReportUrlRenderer getReportUrlRenderer() {
+        reportUrlRenderer
     }
 
     @TaskAction
@@ -50,10 +54,9 @@ class EvaluateViolationsTask extends DefaultTask {
         }
     }
 
-    static String getViolationsMessage(Violations violations) {
-        def consoleRenderer = new ConsoleRenderer()
+    String getViolationsMessage(Violations violations) {
         "$violations.name rule violations were found ($violations.errors errors, $violations.warnings warnings). See the reports at:\n" +
-                "${violations.reports.collect { "- ${consoleRenderer.asClickableFileUrl(it)}" }.join('\n')}"
+                "${violations.reports.collect { "- ${reportUrlRenderer.render(it)}" }.join('\n')}"
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.logging.ConsoleRenderer
 
 class EvaluateViolationsTask extends DefaultTask {
     private PenaltyExtension penaltyExtension
@@ -50,8 +51,9 @@ class EvaluateViolationsTask extends DefaultTask {
     }
 
     static String getViolationsMessage(Violations violations) {
+        def consoleRenderer = new ConsoleRenderer()
         "$violations.name rule violations were found ($violations.errors errors, $violations.warnings warnings). See the reports at:\n" +
-                "${violations.reports.collect { "- $it" }.join('\n')}"
+                "${violations.reports.collect { "- ${consoleRenderer.asClickableFileUrl(it)}" }.join('\n')}"
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -1,12 +1,12 @@
 package com.novoda.staticanalysis
 
 import com.novoda.staticanalysis.internal.Violations
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.TaskAction
 
-class EvaluateViolationsTask extends ConventionTask {
+class EvaluateViolationsTask extends DefaultTask {
     private PenaltyExtension penaltyExtension
     private NamedDomainObjectContainer<Violations> violationsContainer
     private ReportUrlRenderer reportUrlRenderer

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -35,7 +35,7 @@ class EvaluateViolationsTask extends DefaultTask {
             int errors = violations.errors
             int warnings = violations.warnings
             if (errors > 0 || warnings > 0) {
-                fullMessage += "> $violations.message\n"
+                fullMessage += "> ${getViolationsMessage(violations)}\n"
                 total['errors'] += errors
                 total['warnings'] += warnings
             }
@@ -48,4 +48,10 @@ class EvaluateViolationsTask extends DefaultTask {
             project.logger.warn fullMessage
         }
     }
+
+    static String getViolationsMessage(Violations violations) {
+        "$violations.name rule violations were found ($violations.errors errors, $violations.warnings warnings). See the reports at:\n" +
+                "${violations.reports.collect { "- $it" }.join('\n')}"
+    }
+
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
@@ -1,0 +1,33 @@
+package com.novoda.staticanalysis
+
+import org.gradle.api.Project
+
+class LogsExtension {
+
+    private ReportUrlRenderer reportUrlRenderer = ReportUrlRenderer.DEFAULT
+    final Project project
+
+    LogsExtension(Project project) {
+        this.project = project
+    }
+
+    void baseReportUrl(String newBaseUrl, String localBaseUrl = "$project.buildDir/reports") {
+        reportUrlRenderer { reportUrl ->
+            newBaseUrl + reportUrl - ~/$localBaseUrl/
+        }
+    }
+
+    void reportUrlRenderer(Closure<String> renderer) {
+        reportUrlRenderer = new ReportUrlRenderer() {
+            @Override
+            String render(File report) {
+                renderer.call(report.path)
+            }
+        }
+    }
+
+    ReportUrlRenderer getReportUrlRenderer() {
+        reportUrlRenderer
+    }
+
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
@@ -2,6 +2,9 @@ package com.novoda.staticanalysis
 
 import org.gradle.api.Project
 
+/**
+ * This extension can be used to change the rendering of the logs printed by the plugin.
+ */
 class LogsExtension {
 
     private ReportUrlRenderer reportUrlRenderer = ReportUrlRenderer.DEFAULT
@@ -11,19 +14,41 @@ class LogsExtension {
         this.project = project
     }
 
-    void baseReportUrl(String newBaseUrl, String localBaseUrl = "$project.buildDir/reports") {
-        reportUrlRenderer { reportUrl ->
-            newBaseUrl + reportUrl - ~/$localBaseUrl/
-        }
-    }
-
+    /**
+     * This method will create a new {@code ReportUrlRenderer} using the transformation closure provided.
+     * the closure will receive the report as {@code File} and should provide a {@code String} as output.
+     *
+     * Here an example os custom renderer that will render report urls as markdown links (?!):
+     * <pre>
+     *     staticAnalysis {
+     *         ...
+     *         logs {
+     *             reportUrlRenderer { report -> "$[report.name]($report.path)" }
+     *         }
+     *     }
+     * </pre>
+     *
+     * @param renderer a closure that will transform a given {@code File} into a {@code String}
+     */
     void reportUrlRenderer(Closure<String> renderer) {
         reportUrlRenderer = new ReportUrlRenderer() {
             @Override
             String render(File report) {
-                renderer.call(report.path)
+                renderer.call(report)
             }
         }
+    }
+
+    /**
+     * This method provides a convenient way for creating a custom {@code ReportUrlRenderer} that will replace the base
+     * url of each report in the logs with one of choice. The target for the replacement by default is set to the
+     * reports dir of the project, but can be changes if needed.
+     *
+     * @param newBaseUrl the base url to be used
+     * @param localBaseUrl optional, the local base url to be replaced with {@code newBaseUrl}
+     */
+    void baseReportUrl(String newBaseUrl, String localBaseUrl = "$project.buildDir/reports") {
+        reportUrlRenderer { report -> newBaseUrl + (report.path - ~/$localBaseUrl/) }
     }
 
     ReportUrlRenderer getReportUrlRenderer() {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
@@ -47,7 +47,7 @@ class LogsExtension {
      * @param newBaseUrl the base url to be used
      * @param localBaseUrl optional, the local base url to be replaced with {@code newBaseUrl}
      */
-    void baseReportUrl(String newBaseUrl, String localBaseUrl = "$project.buildDir/reports") {
+    void reportBaseUrl(String newBaseUrl, String localBaseUrl = "$project.buildDir/reports") {
         reportUrlRenderer { report -> newBaseUrl + (report.path - ~/$localBaseUrl/) }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/LogsExtension.groovy
@@ -16,14 +16,14 @@ class LogsExtension {
 
     /**
      * This method will create a new {@code ReportUrlRenderer} using the transformation closure provided.
-     * the closure will receive the report as {@code File} and should provide a {@code String} as output.
+     * The closure will receive the report as {@code File} and should provide a {@code String} as output.
      *
-     * Here an example os custom renderer that will render report urls as markdown links (?!):
+     * Here an example of custom renderer that will render report urls as markdown links (?!):
      * <pre>
      *     staticAnalysis {
      *         ...
      *         logs {
-     *             reportUrlRenderer { report -> "$[report.name]($report.path)" }
+     *             reportUrlRenderer { report -> "[$report.name]($report.path)" }
      *         }
      *     }
      * </pre>
@@ -42,7 +42,7 @@ class LogsExtension {
     /**
      * This method provides a convenient way for creating a custom {@code ReportUrlRenderer} that will replace the base
      * url of each report in the logs with one of choice. The target for the replacement by default is set to the
-     * reports dir of the project, but can be changes if needed.
+     * reports dir of the project, but can be changed if needed.
      *
      * @param newBaseUrl the base url to be used
      * @param localBaseUrl optional, the local base url to be replaced with {@code newBaseUrl}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/ReportUrlRenderer.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/ReportUrlRenderer.groovy
@@ -1,0 +1,19 @@
+package com.novoda.staticanalysis
+
+import org.gradle.internal.logging.ConsoleRenderer
+
+interface ReportUrlRenderer {
+
+    String render(File report)
+
+    ReportUrlRenderer DEFAULT = new Default()
+
+    private static class Default implements ReportUrlRenderer {
+        private final ConsoleRenderer consoleRenderer = new ConsoleRenderer()
+        @Override
+        String render(File report) {
+            consoleRenderer.asClickableFileUrl(report)
+        }
+    }
+
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
@@ -1,6 +1,7 @@
 package com.novoda.staticanalysis
 
 import org.gradle.api.Action
+import org.gradle.api.Project
 
 class StaticAnalysisExtension {
 
@@ -20,13 +21,26 @@ class StaticAnalysisExtension {
     }
 
     private PenaltyExtension currentPenalty = new PenaltyExtension()
+    private final LogsExtension logs
+
+    StaticAnalysisExtension(Project project) {
+        this.logs = new LogsExtension(project)
+    }
 
     void penalty(Action<? super PenaltyExtension> action) {
         action.execute(currentPenalty)
     }
 
+    void logs(Action<? super LogsExtension> action) {
+        action.execute(logs)
+    }
+
     PenaltyExtension getPenalty() {
         currentPenalty
+    }
+
+    ReportUrlRenderer getReportUrlRenderer() {
+        logs.reportUrlRenderer
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -20,11 +20,11 @@ class StaticAnalysisPlugin implements Plugin<Project> {
     }
 
     private EvaluateViolationsTask createEvaluateViolationsTask(Project project) {
-        StaticAnalysisExtension extension = project.extensions.create('staticAnalysis', StaticAnalysisExtension)
+        StaticAnalysisExtension extension = project.extensions.create('staticAnalysis', StaticAnalysisExtension, project)
         project.tasks.create('evaluateViolations', EvaluateViolationsTask) { task ->
             task.penaltyExtension = extension.penalty
             task.violationsContainer = project.container(Violations)
-            task.conventionMapping.putAt('reportUrlRenderer', { ReportUrlRenderer.DEFAULT })
+            task.conventionMapping.putAt('reportUrlRenderer', { extension.reportUrlRenderer })
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -24,6 +24,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
         project.tasks.create('evaluateViolations', EvaluateViolationsTask) { task ->
             task.penaltyExtension = extension.penalty
             task.violationsContainer = project.container(Violations)
+            task.conventionMapping.putAt('reportUrlRenderer', { ReportUrlRenderer.DEFAULT })
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
@@ -4,7 +4,7 @@ class Violations {
     private final String toolName
     private int errors = 0
     private int warnings = 0
-    private List<String> reports = []
+    private List<File> reports = []
 
     Violations(String toolName) {
         this.toolName = toolName
@@ -22,15 +22,15 @@ class Violations {
         warnings
     }
 
-    List<String> getReports() {
+    List<File> getReports() {
         return reports
     }
 
-    public void addViolations(int errors, int warnings, String reportUrl) {
+    public void addViolations(int errors, int warnings, File report) {
         this.errors += errors
         this.warnings += warnings
         if (errors > 0 || warnings > 0) {
-            reports += reportUrl
+            reports += report
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
@@ -10,16 +10,20 @@ class Violations {
         this.toolName = toolName
     }
 
-    public String getName() {
+    String getName() {
         return toolName
     }
 
-    public int getErrors() {
+    int getErrors() {
         errors
     }
 
-    public int getWarnings() {
+    int getWarnings() {
         warnings
+    }
+
+    List<String> getReports() {
+        return reports
     }
 
     public void addViolations(int errors, int warnings, String reportUrl) {
@@ -30,8 +34,4 @@ class Violations {
         }
     }
 
-    public String getMessage() {
-        "$toolName rule violations were found ($errors errors, $warnings warnings). See the reports at:\n" +
-                "${reports.collect { "- $it" }.join('\n')}"
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension
-import org.gradle.internal.logging.ConsoleRenderer
 
 class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, CheckstyleExtension> {
 
@@ -75,8 +74,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
             GPathResult xml = new XmlSlurper().parse(xmlReportFile)
             int errors = xml.'**'.findAll { node -> node.name() == 'error' && node.@severity == 'error' }.size()
             int warnings = xml.'**'.findAll { node -> node.name() == 'error' && node.@severity == 'warning' }.size()
-            String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
-            violations.addViolations(errors, warnings, reportUrl)
+            violations.addViolations(errors, warnings, htmlReportFile ?: xmlReportFile)
         }
         evaluateViolations.dependsOn checkstyle
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -9,7 +9,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
 import org.gradle.api.tasks.SourceSet
-import org.gradle.internal.logging.ConsoleRenderer
 
 import java.nio.file.Path
 
@@ -133,8 +132,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     private void evaluateReports(File xmlReportFile, File htmlReportFile) {
         def evaluator = new FinbugsViolationsEvaluator(xmlReportFile)
-        String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile)
-        violations.addViolations(evaluator.errorsCount(), evaluator.warningsCount(), reportUrl)
+        violations.addViolations(evaluator.errorsCount(), evaluator.warningsCount(), htmlReportFile)
     }
 
     private GenerateHtmlReport createHtmlReportTask(FindBugs findBugs, File xmlReportFile, File htmlReportFile) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
-import org.gradle.internal.logging.ConsoleRenderer
 
 class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
@@ -85,7 +84,6 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
                 warnings += 1
             }
         }
-        String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
-        violations.addViolations(errors, warnings, reportUrl)
+        violations.addViolations(errors, warnings, htmlReportFile ?: xmlReportFile)
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
@@ -17,8 +17,8 @@ class LogsConfigurationIntegrationTest {
     final String DEFAULT_CHECKSTYLE_CONFIG = "checkstyle { configFile new File('${Fixtures.Checkstyle.MODULES.path}') }"
 
     @Parameterized.Parameters
-    public static List<Object[]> rules() {
-        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+    public static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()]
     }
 
     @Rule

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
@@ -29,6 +29,26 @@ class LogsConfigurationIntegrationTest {
     }
 
     @Test
+    public void shouldUseCustomReportUrlRendererWhenProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withToolsConfig("""
+                    $DEFAULT_CHECKSTYLE_CONFIG
+                    logs {
+                        reportUrlRenderer { report -> "**\${report.path}**" }
+                    }
+                """)
+                .build('check')
+
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                "**${result.buildFileUrl('reports/checkstyle/main.html')}**")
+    }
+
+    @Test
     public void shouldUseDifferentBaseReportUrlWhenProvided() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
@@ -49,7 +49,7 @@ class LogsConfigurationIntegrationTest {
     }
 
     @Test
-    public void shouldUseDifferentBaseReportUrlWhenProvided() {
+    public void shouldUseDifferentReportBaseUrlWhenProvided() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
@@ -59,7 +59,7 @@ class LogsConfigurationIntegrationTest {
                 .withToolsConfig("""
                     $DEFAULT_CHECKSTYLE_CONFIG
                     logs {
-                        baseReportUrl "what://foo/bar/reports"
+                        reportBaseUrl "what://foo/bar/reports"
                     }
                 """)
                 .build('check')
@@ -68,7 +68,7 @@ class LogsConfigurationIntegrationTest {
     }
 
     @Test
-    public void shouldMatchDifferentBaseReportUrlWhenProvided() {
+    public void shouldMatchDifferentReportBaseUrlWhenProvided() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
@@ -78,7 +78,7 @@ class LogsConfigurationIntegrationTest {
                 .withToolsConfig("""
                     $DEFAULT_CHECKSTYLE_CONFIG
                     logs {
-                        baseReportUrl "what://foo/bar", "\${project.buildDir}/reports"
+                        reportBaseUrl "what://foo/bar", "\${project.buildDir}/reports"
                     }
                 """)
                 .build('check')

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/LogsConfigurationIntegrationTest.groovy
@@ -1,0 +1,68 @@
+package com.novoda.staticanalysis.internal
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.LogsSubject.assertThat
+
+@RunWith(Parameterized.class)
+class LogsConfigurationIntegrationTest {
+
+    private static
+    final String DEFAULT_CHECKSTYLE_CONFIG = "checkstyle { configFile new File('${Fixtures.Checkstyle.MODULES.path}') }"
+
+    @Parameterized.Parameters
+    public static List<Object[]> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    public LogsConfigurationIntegrationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    public void shouldUseDifferentBaseReportUrlWhenProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withToolsConfig("""
+                    $DEFAULT_CHECKSTYLE_CONFIG
+                    logs {
+                        baseReportUrl "what://foo/bar/reports"
+                    }
+                """)
+                .build('check')
+
+        assertThat(result.logs).containsCheckstyleViolations(0, 1, 'what://foo/bar/reports/checkstyle/main.html')
+    }
+
+    @Test
+    public void shouldMatchDifferentBaseReportUrlWhenProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withToolsConfig("""
+                    $DEFAULT_CHECKSTYLE_CONFIG
+                    logs {
+                        baseReportUrl "what://foo/bar", "\${project.buildDir}/reports"
+                    }
+                """)
+                .build('check')
+
+        assertThat(result.logs).containsCheckstyleViolations(0, 1, 'what://foo/bar/checkstyle/main.html')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
@@ -16,8 +16,8 @@ public class CheckstyleIntegrationTest {
     public static final String DEFAULT_CONFIG = "configFile new File('${Fixtures.Checkstyle.MODULES.path}')"
 
     @Parameterized.Parameters
-    public static List<Object[]> rules() {
-        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+    public static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()]
     }
 
     @Rule

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -17,8 +17,8 @@ import static com.novoda.test.TestProjectSubject.assumeThat
 class FindbugsIntegrationTest {
 
     @Parameterized.Parameters
-    public static List<Object[]> rules() {
-        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+    public static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()]
     }
 
     @Rule

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
@@ -16,8 +16,8 @@ public class PmdIntegrationTest {
     private static final String DEFAULT_RULES = "project.files('${Fixtures.Pmd.RULES.path}')"
 
     @Parameterized.Parameters
-    public static List<Object[]> rules() {
-        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+    public static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()]
     }
 
     @Rule


### PR DESCRIPTION
> Tracked by [PT-442](https://novoda.atlassian.net/browse/PT-442)

## Scope of the PR

When running static analyses the output always refers to local file URLs for reports which is fine on a local machine but unusable for CI logs.

## Considerations and implementation

- Introduced `ReportUrlRenderer` as delegate to render a report URL in the logs. Default implementation will render URLs using `ConsoleRenderer` from Gradle.
- Introduced `LogsExtension` to allow users to specify custom renderers as simple closure `(File) -> String`. `LogsExtension` exposes a `reportBaseUrl` as convenience method that will allow to swap the default base url of reports with one of choice.

### Test(s) added 

`LogsConfigurationIntegrationTest` is now checking basic configuration of `LogsExtension` including usage built-in convenience methods.
