### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+[Version 0.3.2](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3.2)
+--------------------------
+
+- Better classes filtering for Findbugs tasks ([PR#23](https://github.com/novoda/gradle-static-analysis-plugin/pull/23))
+
 [Version 0.3.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3.1)
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.3.1'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.3.2'
     }
 }
 ```

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,4 +1,4 @@
-version = '0.3.1'
+version = '0.3.2'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Static Analysis Plugin'
 


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #23.

## Considerations and implementation
- Bumped version for release
- Updated `README`
- Updated `CHANGELOG`
