### PR TITLE
PT-273/PT-450: Add support for rules as Maven artifact

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,7 +1,3 @@
-repositories {
-    jcenter()
-}
-
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply from: rootProject.file('gradle/publish.gradle')

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/RulesExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/RulesExtension.groovy
@@ -1,0 +1,26 @@
+package com.novoda.staticanalysis
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.resources.TextResource
+
+class RulesExtension {
+    final String name
+    final Project project
+    Configuration configuration
+
+    RulesExtension(String name, Project project) {
+        this.name = name
+        this.project = project
+    }
+
+    void maven(String coordinates) {
+        def configurationName = "staticAnalysis${name.capitalize()}"
+        configuration = project.configurations.create(configurationName)
+        project.dependencies.add(configurationName, coordinates)
+    }
+
+    TextResource getAt(String relativePath) {
+        project.resources.text.fromArchiveEntry(configuration, relativePath)
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
@@ -1,6 +1,8 @@
 package com.novoda.staticanalysis
 
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Project
 
 class StaticAnalysisExtension {
@@ -22,9 +24,16 @@ class StaticAnalysisExtension {
 
     private PenaltyExtension currentPenalty = new PenaltyExtension()
     private final LogsExtension logs
+    private final NamedDomainObjectContainer<RulesExtension> rules
 
     StaticAnalysisExtension(Project project) {
         this.logs = new LogsExtension(project)
+        this.rules = project.container(RulesExtension, new NamedDomainObjectFactory<RulesExtension>() {
+            @Override
+            RulesExtension create(String name) {
+                new RulesExtension(name, project)
+            }
+        })
     }
 
     void penalty(Action<? super PenaltyExtension> action) {
@@ -35,12 +44,20 @@ class StaticAnalysisExtension {
         action.execute(logs)
     }
 
+    void rules(Action<? super NamedDomainObjectContainer<RulesExtension>> action) {
+        action.execute(rules)
+    }
+
     PenaltyExtension getPenalty() {
         currentPenalty
     }
 
     ReportUrlRenderer getReportUrlRenderer() {
         logs.reportUrlRenderer
+    }
+
+    NamedDomainObjectContainer<RulesExtension> getRules() {
+        rules
     }
 
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/RulesIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/RulesIntegrationTest.groovy
@@ -1,0 +1,59 @@
+package com.novoda.staticanalysis
+
+import com.novoda.test.DeployRulesTestRule
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.LogsSubject.assertThat
+
+@RunWith(Parameterized.class)
+class RulesIntegrationTest {
+
+    @ClassRule
+    public static final DeployRulesTestRule DEPLOY_RULES = new DeployRulesTestRule(
+            resourceDirs: [Fixtures.Checkstyle.MODULES.parentFile.parentFile.parentFile],
+            repoDir: new File(Fixtures.BUILD_DIR, 'rules'))
+
+    @Parameterized.Parameters
+    public static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    RulesIntegrationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    public void shouldUseConfigurationFromArtifactWhenProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withAdditionalConfiguration("repositories { maven { url '$DEPLOY_RULES.repoDir' } }")
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxWarnings = 0
+                    maxErrors = 0
+                }''')
+                .withToolsConfig("""
+                    rules {
+                        novoda { maven '$DEPLOY_RULES.mavenCoordinates' }
+                    }
+                    checkstyle {
+                       config rules.novoda['checkstyle/config/modules.xml']
+                    }
+                """)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 1)
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                result.buildFileUrl('reports/checkstyle/main.html'))
+    }
+
+}

--- a/plugin/src/test/groovy/com/novoda/test/DeployRulesTestRule.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/DeployRulesTestRule.groovy
@@ -1,0 +1,92 @@
+package com.novoda.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class DeployRulesTestRule implements TestRule {
+
+    List<File> resourceDirs
+    File repoDir
+    String groupId = 'test'
+    String artifactId = 'rules'
+    String version = 'unreleased'
+
+    String getMavenCoordinates() {
+        "$groupId:$artifactId:$version"
+    }
+
+    @Override
+    Statement apply(Statement base, Description description) {
+        new Statement() {
+            @Override
+            void evaluate() throws Throwable {
+                cleanRepo()
+                File projectDir = createProjectDir("${System.currentTimeMillis()}")
+                createBuildScript(projectDir)
+                GradleRunner.create()
+                        .withProjectDir(projectDir)
+                        .withDebug(true)
+                        .forwardStdOutput(new OutputStreamWriter(System.out))
+                        .forwardStdError(new OutputStreamWriter(System.out))
+                        .withArguments('clean', 'publish')
+                        .build()
+                base.evaluate()
+                projectDir.deleteDir()
+            }
+
+        }
+    }
+
+    private void cleanRepo() {
+        def artifactDir = new File(repoDir, "${groupId.replace('.', '/')}/$artifactId/$version")
+        if (artifactDir.exists()) {
+            artifactDir.deleteDir()
+        }
+    }
+
+    private void createBuildScript(File projectDir) {
+        new File(projectDir, 'build.gradle').text = """
+buildscript {
+    repositories {
+        jcenter()
+    }
+}
+
+version='$version'
+
+apply plugin: 'java'
+
+sourceSets {
+    main {
+        resources {
+            srcDirs = ${resourceDirs.collect { "'$it.path'" }}
+        }
+    }
+}
+
+apply plugin: 'maven-publish'
+
+publishing {
+    repositories {
+        maven { url '${repoDir}' }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+            groupId '$groupId'
+            artifactId '$artifactId'
+            from components.java
+        }
+    }
+}"""
+    }
+
+    private static File createProjectDir(String path) {
+        File dir = new File(Fixtures.BUILD_DIR, "test-projects/$path")
+        dir.deleteDir()
+        dir.mkdirs()
+        return dir
+    }
+
+}


### PR DESCRIPTION
> Tracked by [PT-450](https://novoda.atlassian.net/browse/PT-450)

## Scope of the PR
We would like to provide a way to consume the same set of rules cross-projects for all the static analysis tools we intend to use. A viable way to share such rules is as maven artifact (JAR).

## Considerations and implementation
Added a container of `RulesExtension` to `StaticAnalysisExtension` that can be used to define artifacts containing rules we want to use to configure the static analysis tools, eg:
```
staticAnalysis {
  rules {
    novoda {
      maven 'foo.bar:static-analysis-rules:0.1'
    }
  }
  checkstyle {
    config rules.novoda['checkstyle/modules.xml']
  }
}
```
where `foo.bar:static-analysis-rules:0.1` is a JAR deployed to a maven repository of choice. The  configuration XML file can be accessed via the `getAt` operator providing the relative path inside the JAR. It is then retrieved as `TextResource` that can be fed - for instance - to `checkstyle.config` or anywhere such type is supported.



### Test(s) added 
Added `RulesIntegrationTest` to check the new feature. To help with the setup we introduced a `DeployRulesTestRule` in order to create and then deploy a set of rules as JAR artifact into a local maven repo that can be used in the integration test.


