### PR TITLE
PT-447: Explicitly include Android variants in analysis

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -3,6 +3,7 @@ package com.novoda.staticanalysis.internal
 import com.novoda.staticanalysis.EvaluateViolationsTask
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.tasks.SourceTask
@@ -64,7 +65,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
         }
     }
 
-    protected abstract void configureAndroidProject(Object variants)
+    protected abstract void configureAndroidProject(NamedDomainObjectSet variants)
 
     protected void configureJavaProject() {
         project.tasks.withType(taskClass) { task -> sourceFilter.applyTo(task) }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -5,6 +5,7 @@ import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension
@@ -41,7 +42,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     }
 
     @Override
-    protected void configureAndroidProject(Object variants) {
+    protected void configureAndroidProject(NamedDomainObjectSet variants) {
         project.with {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -3,6 +3,7 @@ package com.novoda.staticanalysis.internal.findbugs
 import com.novoda.staticanalysis.EvaluateViolationsTask
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
@@ -49,7 +50,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     @Override
-    protected void configureAndroidProject(Object variants) {
+    protected void configureAndroidProject(NamedDomainObjectSet variants) {
         variants.all { variant ->
             FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
             List<File> androidSourceDirs = variant.sourceSets.collect { it.javaDirectories }.flatten()

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -5,6 +5,7 @@ import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
 import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
@@ -42,7 +43,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     }
 
     @Override
-    protected void configureAndroidProject(Object variants) {
+    protected void configureAndroidProject(NamedDomainObjectSet variants) {
         project.with {
             variants.all { variant ->
                 variant.sourceSets.each { sourceSet ->

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleAndroidVariantIntegrationTest.groovy
@@ -20,23 +20,6 @@ class CheckstyleAndroidVariantIntegrationTest {
     public final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
 
     @Test
-    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInApplicationVariant() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withPenalty('''{
-                    maxErrors = 0
-                    maxWarnings = 0
-                }''')
-                .withToolsConfig(DEFAULT_CHECKSTYLE_CONFIG)
-                .buildAndFail('check')
-
-        assertThat(result.logs).containsLimitExceeded(0, 1)
-        assertThat(result.logs).containsCheckstyleViolations(0, 1,
-                result.buildFileUrl('reports/checkstyle/main.html'))
-    }
-
-
-    @Test
     public void shouldNotFailBuildWhenCheckstyleViolationsBelowThresholdInApplicationVariant() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
@@ -89,30 +72,6 @@ class CheckstyleAndroidVariantIntegrationTest {
     }
 
     @Test
-    public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInProductFlavorVariant() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('''{
-                    maxErrors = 0
-                    maxWarnings = 1
-                }''')
-                .withAdditionalAndroidConfig('''
-                    productFlavors {
-                        demo
-                    }
-                ''')
-                .withToolsConfig(DEFAULT_CHECKSTYLE_CONFIG)
-                .buildAndFail('check')
-
-        assertThat(result.logs).containsLimitExceeded(1, 0)
-        assertThat(result.logs).containsCheckstyleViolations(1, 1,
-                result.buildFileUrl('reports/checkstyle/main.html'),
-                result.buildFileUrl('reports/checkstyle/demo.html'))
-    }
-
-    @Test
     public void shouldFailBuildWhenCheckstyleViolationsOverThresholdInActiveProductFlavorVariant() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
@@ -141,32 +100,6 @@ class CheckstyleAndroidVariantIntegrationTest {
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFileUrl('reports/checkstyle/main.html'),
                 result.buildFileUrl('reports/checkstyle/demo.html'))
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenCheckstyleViolationsOverThresholdInIgnoredVariants() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('''{
-                    maxErrors = 0
-                    maxWarnings = 1
-                }''')
-                .withAdditionalAndroidConfig('''
-                    productFlavors {
-                        demo
-                        full
-                    }
-
-                    variantFilter { variant ->
-                        variant.setIgnore(true);
-                    }
-                ''')
-                .withToolsConfig(DEFAULT_CHECKSTYLE_CONFIG)
-                .build('check')
-
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
     }
 
     @Test
@@ -218,7 +151,7 @@ class CheckstyleAndroidVariantIntegrationTest {
     }
 
     @Test
-    public void shouldNotFailBuildWhenCheckstyleViolationsBelowThresholdInIncludedVariants() {
+    public void shouldContainCheckstyleTasksForIncludedVariantsOnly() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
@@ -245,32 +178,6 @@ class CheckstyleAndroidVariantIntegrationTest {
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFileUrl('reports/checkstyle/main.html'),
                 result.buildFileUrl('reports/checkstyle/demo.html'))
-    }
-
-    @Test
-    public void shouldContainCheckstyleTasksForIncludedVariantsOnly() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('demo', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withSourceSet('full', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('''{
-                    maxErrors = 1
-                    maxWarnings = 1
-                }''')
-                .withAdditionalAndroidConfig('''
-                    productFlavors {
-                        demo
-                        full
-                    }
-                ''')
-                .withToolsConfig("""
-                    checkstyle {
-                        configFile new File('${Fixtures.Checkstyle.MODULES.path}')
-                        includeVariants { variant -> variant.name.equals('demoDebug') }
-                    }
-                """)
-                .build('check')
-
         def checkstyleTasks = result.tasksPaths.findAll { it.startsWith(':checkstyle') }
         Truth.assertThat(checkstyleTasks).containsAllIn([
                 ":checkstyleDebug",

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsAndroidVariantIntegrationTest.groovy
@@ -1,0 +1,277 @@
+package com.novoda.staticanalysis.internal.findbugs
+
+import com.google.common.truth.Truth
+import com.novoda.test.Fixtures
+import com.novoda.test.TestAndroidProject
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+import static com.novoda.test.LogsSubject.assertThat
+
+class FindbugsAndroidVariantIntegrationTest {
+
+    private static final String DEFAULT_FINDBUGS_CONFIG = "findbugs {}"
+
+    @Rule
+    public final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
+
+    @Test
+    public void shouldFailBuildWhenFindbugsViolationsOverThresholdInDefaultApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 2)
+        assertThat(result.logs).containsFindbugsViolations(0, 2,
+                result.buildFileUrl('reports/findbugs/debug.html'),
+                result.buildFileUrl('reports/findbugs/release.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsViolationsBelowThresholdInDefaultApplicationVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsFindbugsViolations(0, 2,
+                result.buildFileUrl('reports/findbugs/debug.html'),
+                result.buildFileUrl('reports/findbugs/release.html'))
+    }
+
+
+    @Test
+    public void shouldFailBuildWhenFindbugsViolationsOverThresholdInUnitTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('test', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(2, 0)
+        assertThat(result.logs).containsFindbugsViolations(2, 2,
+                result.buildFileUrl('reports/findbugs/debug.html'),
+                result.buildFileUrl('reports/findbugs/release.html'),
+                result.buildFileUrl('reports/findbugs/debugUnitTest.html'),
+                result.buildFileUrl('reports/findbugs/releaseUnitTest.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenFindbugsViolationsOverThresholdInAndroidTestVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('androidTest', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsFindbugsViolations(1, 2,
+                result.buildFileUrl('reports/findbugs/debug.html'),
+                result.buildFileUrl('reports/findbugs/release.html'),
+                result.buildFileUrl('reports/findbugs/debugAndroidTest.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenFindbugsViolationsOverThresholdInProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                    }
+                ''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(2, 0)
+        assertThat(result.logs).containsFindbugsViolations(2, 2,
+                result.buildFileUrl('reports/findbugs/demoDebug.html'),
+                result.buildFileUrl('reports/findbugs/demoRelease.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenFindbugsViolationsOverThresholdInActiveProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        if(variant.name.contains('full')) {
+                            variant.setIgnore(true);
+                        }
+                    }
+                ''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(2, 0)
+        assertThat(result.logs).containsFindbugsViolations(2, 2,
+                result.buildFileUrl('reports/findbugs/demoDebug.html'),
+                result.buildFileUrl('reports/findbugs/demoRelease.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsViolationsOverThresholdInIgnoredProductFlavorVariants() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 2
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+
+                    variantFilter { variant ->
+                        variant.setIgnore(true)
+                    }
+                ''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainFindbugsViolations()
+    }
+
+    @Test
+    public void shouldContainFindbugsTasksForAllVariantsByDefault() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 1
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+                ''')
+                .withToolsConfig(DEFAULT_FINDBUGS_CONFIG)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(3, 3)
+        assertThat(result.logs).containsFindbugsViolations(4, 4,
+                result.buildFileUrl('reports/findbugs/demoDebug.html'),
+                result.buildFileUrl('reports/findbugs/demoRelease.html'),
+                result.buildFileUrl('reports/findbugs/fullDebug.html'),
+                result.buildFileUrl('reports/findbugs/fullRelease.html'))
+        Truth.assertThat(result.tasksPaths.findAll { it.startsWith(':findbugs') }).containsAllIn([
+                ":findbugsDemoDebug",
+                ":findbugsDemoDebugUnitTest",
+                ":findbugsDemoDebugAndroidTest",
+                ":findbugsDemoRelease",
+                ":findbugsDemoReleaseUnitTest",
+                ":findbugsFullDebug",
+                ":findbugsFullDebugUnitTest",
+                ":findbugsFullRelease",
+                ":findbugsFullReleaseUnitTest"])
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsViolationsBelowThresholdInIncludedVariants() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 1
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+                ''')
+                .withToolsConfig("""
+                    findbugs {
+                        includeVariants { variant -> variant.name.equals('demoDebug') }
+                    }
+                """)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsFindbugsViolations(1, 1,
+                result.buildFileUrl('reports/findbugs/demoDebug.html'))
+    }
+
+    @Test
+    public void shouldContainFindbugsTasksForIncludedVariantsOnly() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('demo', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withSourceSet('full', Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 1
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    productFlavors {
+                        demo
+                        full
+                    }
+                ''')
+                .withToolsConfig("""
+                    findbugs {
+                        includeVariants { variant -> variant.name.equals('demoDebug') }
+                    }
+                """)
+                .build('check')
+
+        def findbugsTasks = result.tasksPaths.findAll { it.startsWith(':findbugs') }
+        Truth.assertThat(findbugsTasks).containsAllIn([":findbugsDemoDebug"])
+        Truth.assertThat(findbugsTasks).containsNoneIn([
+                ":findbugsDemoDebugUnitTest",
+                ":findbugsDemoDebugAndroidTest",
+                ":findbugsDemoRelease",
+                ":findbugsDemoReleaseUnitTest",
+                ":findbugsFullDebug",
+                ":findbugsFullDebugUnitTest",
+                ":findbugsFullRelease",
+                ":findbugsFullReleaseUnitTest"])
+    }
+
+}

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -131,6 +131,10 @@ ${project.additionalConfiguration}
             new File(buildDir, path).path
         }
 
+        List<String> getTasksPaths() {
+            buildResult.tasks.collect { it.path }
+        }
+
         @Nullable
         TaskOutcome outcome(String taskPath) {
             buildResult.task(taskPath).outcome


### PR DESCRIPTION
> Tracked by [PT-447](https://novoda.atlassian.net/browse/PT-447)

## Scope of the PR
When applying the plugin we want to skip the creation of tasks for certain Android variants to speed up the whole analysis. After discussing this with @ouchadam and @devisnik we agreed it would be cool to have an explicit way to tell the plugin which Android variants should be considered and which shouldn't.

## Considerations and implementation
Each `*Configurator` now decorates the tool specific extension with an `includeVariants` method that will receive a predicate used to decide which variant should be considered as part of the analysis. Eg:
```
staticAnalsysis {
  findbugs {
    includeVariant { variant -> variant.name.equals('debug') }
  }
}
```
By default - for the moment - all variants will be included unless an explicit predicate is provided via `includeVariants`.

### Test(s) added 
Few integration tests have been added to validate that tasks related to excluded variants are not created by the plugin. Incidentally some redundant integration test has been removed because their scenarios were already covered.

