### PR TITLE
Release v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+[Version 0.4](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.4)
+--------------------------
+
+- Filtering for Android variants ([PR#28](https://github.com/novoda/gradle-static-analysis-plugin/pull/28))
+- Support for rules as maven artifact ([PR#27](https://github.com/novoda/gradle-static-analysis-plugin/pull/27))
+
 [Version 0.3.2](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3.2)
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ staticAnalysis {
 }
 ```
 
+#### Support for Android variants
+Sometimes using `exclude` filters could be not enough. When using the plugin in an Android project you may want to consider
+only one specific variant as part of the analysis. The plugin provides a way of defining which Android variant should be included
+via the `includeVariants` method added to each tool extension. Eg:
+```
+staticAnalysis {
+    findbugs {
+        includeVariants { variant ->
+            variant.name.equals('debug') // only the debug variant
+        }
+    }
+}
+```
+
 ### Current status / Roadmap
 
 The plugin is **under early development** and to be considered in pre-alpha stage.
@@ -128,5 +142,5 @@ Tool | Android | Java | Documentation |
 
 #### Support for sharable configurations
 
-We plan to add support for consuming rules (eg: configuration files for Checkstyle or PMD, default exclude filters, etc) via a
+The plugin can consume rules (eg: configuration files for Checkstyle or PMD, default exclude filters, etc) via a
 separate artifact you can share across projects. _More info to come._

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ Tool | Android | Java | Documentation |
 #### Support for sharable configurations
 
 The plugin can consume rules (eg: configuration files for Checkstyle or PMD, default exclude filters, etc) via a
-separate artifact you can share across projects. _More info to come._
+separate artifact you can share across projects.

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,4 +1,4 @@
-version = '0.3.2'
+version = '0.4'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Static Analysis Plugin'
 


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #27 and #28.

## Considerations and implementation
- Bumped version for release
- Updated `README`
- Updated `CHANGELOG`
