### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 Change Log
 ==========
 
+[Version 0.4.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.4.1)
+--------------------------
+
+- Ensure invariant over multiple successive runs ([PR#30](https://github.com/novoda/gradle-static-analysis-plugin/pull/30))
+
 [Version 0.4](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.4)
 --------------------------
 
 - Filtering for Android variants ([PR#28](https://github.com/novoda/gradle-static-analysis-plugin/pull/28))
 - Support for rules as maven artifact ([PR#27](https://github.com/novoda/gradle-static-analysis-plugin/pull/27))
+- Added support for custom base url for reports in logs ([PR#25](https://github.com/novoda/gradle-static-analysis-plugin/pull/25))
 
 [Version 0.3.2](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.3.2)
 --------------------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.4'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.4.1'
     }
 }
 ```

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,4 +1,4 @@
-version = '0.4'
+version = '0.4.1'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Static Analysis Plugin'
 


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #30.

## Considerations and implementation
- Bumped version for release
- Updated `README`
- Updated `CHANGELOG`
