### PR TITLE
Introduce dependencies plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,14 @@
+apply plugin: DependenciesPlugin
+
 subprojects {
     buildscript {
         repositories {
             jcenter()
         }
         dependencies {
-            classpath 'com.novoda:bintray-release:0.4.0'
-            classpath 'com.novoda:gradle-build-properties-plugin:0.2'
-            classpath 'org.ajoberstar:gradle-git:1.6.0'
+            classpath gradlePlugins.bintrayRelease
+            classpath gradlePlugins.buildProperties
+            classpath gradlePlugins.gradleGit
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,4 +15,11 @@ subprojects {
     repositories {
         jcenter()
     }
+
+    project.plugins.withType(JavaBasePlugin) {
+        project.with {
+            sourceCompatibility = JavaVersion.VERSION_1_7
+            targetCompatibility = JavaVersion.VERSION_1_7
+        }
+    }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,9 @@
+repositories {
+    jcenter()
+}
+
+apply plugin: 'groovy'
+
+dependencies {
+    compile gradleApi()
+}

--- a/buildSrc/src/main/groovy/DependenciesPlugin.groovy
+++ b/buildSrc/src/main/groovy/DependenciesPlugin.groovy
@@ -1,0 +1,12 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class DependenciesPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.extensions.create('gradlePlugins', GradlePlugins)
+        project.extensions.create('libraries', Libraries, project)
+    }
+
+}

--- a/buildSrc/src/main/groovy/DependenciesPlugin.groovy
+++ b/buildSrc/src/main/groovy/DependenciesPlugin.groovy
@@ -8,5 +8,4 @@ class DependenciesPlugin implements Plugin<Project> {
         project.extensions.create('gradlePlugins', GradlePlugins)
         project.extensions.create('libraries', Libraries, project)
     }
-
 }

--- a/buildSrc/src/main/groovy/GradlePlugins.groovy
+++ b/buildSrc/src/main/groovy/GradlePlugins.groovy
@@ -1,4 +1,4 @@
-public class GradlePlugins {
+class GradlePlugins {
     final bintrayRelease = 'com.novoda:bintray-release:0.4.0'
     final buildProperties = 'com.novoda:gradle-build-properties-plugin:0.2'
     final gradleGit = 'org.ajoberstar:gradle-git:1.6.0'

--- a/buildSrc/src/main/groovy/GradlePlugins.groovy
+++ b/buildSrc/src/main/groovy/GradlePlugins.groovy
@@ -1,0 +1,5 @@
+public class GradlePlugins {
+    public final String bintrayRelease = 'com.novoda:bintray-release:0.4.0'
+    public final String buildProperties = 'com.novoda:gradle-build-properties-plugin:0.2'
+    public final String gradleGit = 'org.ajoberstar:gradle-git:1.6.0'
+}

--- a/buildSrc/src/main/groovy/GradlePlugins.groovy
+++ b/buildSrc/src/main/groovy/GradlePlugins.groovy
@@ -1,5 +1,5 @@
 public class GradlePlugins {
-    public final String bintrayRelease = 'com.novoda:bintray-release:0.4.0'
-    public final String buildProperties = 'com.novoda:gradle-build-properties-plugin:0.2'
-    public final String gradleGit = 'org.ajoberstar:gradle-git:1.6.0'
+    final bintrayRelease = 'com.novoda:bintray-release:0.4.0'
+    final buildProperties = 'com.novoda:gradle-build-properties-plugin:0.2'
+    final gradleGit = 'org.ajoberstar:gradle-git:1.6.0'
 }

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -2,10 +2,10 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 
 public class Libraries {
-    public final String junit = 'junit:junit:4.12'
-    public final String truth = 'com.google.truth:truth:0.30'
-    public final String guava = 'com.google.guava:guava:19.0'
-    public final Findbugs findbugs = new Findbugs()
+    final junit = 'junit:junit:4.12'
+    final truth = 'com.google.truth:truth:0.30'
+    final guava = 'com.google.guava:guava:19.0'
+    final findbugs = new Findbugs()
 
     private final Project project
 
@@ -13,15 +13,15 @@ public class Libraries {
         this.project = project
     }
 
-    public Dependency getGradleApi() {
+    def getGradleApi() {
         project.dependencies.gradleApi()
     }
 
-    public Dependency getGradleTestKit() {
+    def getGradleTestKit() {
         project.dependencies.gradleTestKit()
     }
 
     private static class Findbugs {
-        public final String annotations = 'com.google.code.findbugs:jsr305:3.0.0'
+        final annotations = 'com.google.code.findbugs:jsr305:3.0.0'
     }
 }

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -2,16 +2,16 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 
 public class Libraries {
+    public final String junit = 'junit:junit:4.12'
+    public final String truth = 'com.google.truth:truth:0.30'
+    public final String guava = 'com.google.guava:guava:19.0'
+    public final Findbugs findbugs = new Findbugs()
+
     private final Project project
 
     public Libraries(Project project) {
         this.project = project
     }
-
-    public final String junit = 'junit:junit:4.12'
-    public final String truth = 'com.google.truth:truth:0.30'
-    public final String guava = 'com.google.guava:guava:19.0'
-    public final Findbugs findbugs = new Findbugs()
 
     public Dependency getGradleApi() {
         project.dependencies.gradleApi()

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.artifacts.Dependency
 public class Libraries {
     private final Project project
 
-    Libraries(Project project) {
+    public Libraries(Project project) {
         this.project = project
     }
 

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -1,7 +1,7 @@
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 
-public class Libraries {
+class Libraries {
     final junit = 'junit:junit:4.12'
     final truth = 'com.google.truth:truth:0.30'
     final guava = 'com.google.guava:guava:19.0'

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -1,0 +1,27 @@
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+
+public class Libraries {
+    private final Project project
+
+    Libraries(Project project) {
+        this.project = project
+    }
+
+    public final String junit = 'junit:junit:4.12'
+    public final String truth = 'com.google.truth:truth:0.30'
+    public final String guava = 'com.google.guava:guava:19.0'
+    public final Findbugs findbugs = new Findbugs()
+
+    public Dependency getGradleApi() {
+        project.dependencies.gradleApi()
+    }
+
+    public Dependency getGradleTestKit() {
+        project.dependencies.gradleTestKit()
+    }
+
+    private static class Findbugs {
+        public final String annotations = 'com.google.code.findbugs:jsr305:3.0.0'
+    }
+}

--- a/buildSrc/src/main/groovy/Libraries.groovy
+++ b/buildSrc/src/main/groovy/Libraries.groovy
@@ -1,5 +1,4 @@
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 
 class Libraries {
     final junit = 'junit:junit:4.12'
@@ -9,7 +8,7 @@ class Libraries {
 
     private final Project project
 
-    public Libraries(Project project) {
+    Libraries(Project project) {
         this.project = project
     }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -2,9 +2,6 @@ apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply from: rootProject.file('gradle/publish.gradle')
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
-
 sourceSets {
     test {
         java {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -23,13 +23,13 @@ sourceSets {
 }
 
 dependencies {
-    compile gradleApi()
+    compile libraries.gradleApi
 
-    testCompile gradleTestKit()
-    testCompile 'junit:junit:4.12'
-    testCompile 'com.google.truth:truth:0.30'
-    testCompile 'com.google.guava:guava:19.0'
-    testCompile 'com.google.code.findbugs:jsr305:3.0.0'
+    testCompile libraries.gradleTestKit
+    testCompile libraries.junit
+    testCompile libraries.truth
+    testCompile libraries.guava
+    testCompile libraries.findbugs.annotations
 
     testRuntime files(pluginUnderTestMetadata)
 }


### PR DESCRIPTION
## Scope of the PR
We want to streamline the definition of dependencies in the project. We usually extract a [gradle script](https://github.com/mr-archano/Playground/blob/develop/gradle/dependencies.gradle) collecting all the dependencies as nested maps we can use in every sub project.
This approach, altho helps to tidy up the buildscripts across modules has a big disadvantage: there is no autocompletion provided by the IDE because the handles of each dependency are added dynamically to the properties extension of the project the script is applied to.

## Considerations and implementation
The solution proposed here is to introduce a custom plugin that simply exposes the centralised list of dependencies via project extensions:

- `libraries`: an instance of the `Libraries` class exposing a public property for each of the compile dependencies used in the sub-projects
- `gradlePlugins`: an instance of the `GradlePlugins` class exposing a public property for each of the gradle plugins used in the sub-projects

All you need to do is to apply the plugin to the root project and then access those project extensions, eg:
```
classpath gradlePlugins.bintrayRelease
```
or
```
testCompile libraries.junit
```
