### PR TITLE
[PT-498]: Expect the user to apply detekt manually

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -34,8 +34,6 @@ class DetektConfigurator implements Configurator {
                 return
             }
 
-            project.apply plugin: 'io.gitlab.arturbosch.detekt'
-
             project.extensions.findByName('detekt').with {
                 // apply configuration closure to detekt extension
                 config.delegate = it

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -36,7 +36,7 @@ class DetektConfigurator implements Configurator {
             }
 
             if (!project.tasks.findByName('detektCheck')) {
-                throw new GradleException('The Detekt plugin is configured but not applied. Please apply the plugin in your build script.')
+                throw new GradleException('The detekt plugin is configured but not applied. Please apply the plugin in your build script.')
             }
 
             project.extensions.findByName('detekt').with {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -10,6 +10,9 @@ import org.gradle.api.Task
 
 class DetektConfigurator implements Configurator {
 
+    private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
+    private static final String DETEKT_NOT_APPLIED = 'The detekt plugin is configured but not applied. Please apply the plugin in your build script.'
+
     private final Project project
     private final Violations violations
     private final Task evaluateViolations
@@ -35,8 +38,8 @@ class DetektConfigurator implements Configurator {
                 return
             }
 
-            if (!project.tasks.findByName('detektCheck')) {
-                throw new GradleException('The detekt plugin is configured but not applied. Please apply the plugin in your build script.')
+            if (!project.plugins.hasPlugin(DETEKT_PLUGIN)) {
+                throw new GradleException(DETEKT_NOT_APPLIED)
             }
 
             project.extensions.findByName('detekt').with {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -3,6 +3,7 @@ package com.novoda.staticanalysis.internal.detekt
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.internal.Violations
+import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -34,15 +35,17 @@ class DetektConfigurator implements Configurator {
                 return
             }
 
+            if (!project.tasks.findByName('detektCheck')) {
+                throw new GradleException('The Detekt plugin is configured but not applied. Please apply the plugin in your build script.')
+            }
+
             project.extensions.findByName('detekt').with {
                 // apply configuration closure to detekt extension
                 config.delegate = it
                 config()
             }
 
-            if (project.tasks.findByName('detektCheck')) {
-                configureToolTask()
-            }
+            configureToolTask()
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -11,7 +11,7 @@ import org.gradle.api.Task
 class DetektConfigurator implements Configurator {
 
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
-    private static final String DETEKT_NOT_APPLIED = 'The detekt plugin is configured but not applied. Please apply the plugin in your build script.'
+    private static final String DETEKT_NOT_APPLIED = 'The detekt plugin is configured but not applied. Please apply the plugin in your build script For more information see https://github.com/arturbosch/detekt.'
 
     private final Project project
     private final Violations violations

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -10,7 +10,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION
 import static com.novoda.test.LogsSubject.assertThat
 
 @RunWith(Parameterized.class)
@@ -36,6 +35,7 @@ class DetektIntegrationTest {
     @Test
     void shouldFailBuildWhenDetektWarningsOverTheThreshold() {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 0
@@ -68,6 +68,7 @@ class DetektIntegrationTest {
     @Test
     void shouldFailBuildWhenDetektErrorsOverTheThreshold() {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 0
@@ -97,6 +98,7 @@ class DetektIntegrationTest {
     @Test
     void shouldNotFailWhenDetektIsNotConfigured() throws Exception {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 0
@@ -112,6 +114,7 @@ class DetektIntegrationTest {
     @Test
     void shouldNotFailWhenWarningsAreWithinThreshold() throws Exception {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 1
@@ -140,6 +143,7 @@ class DetektIntegrationTest {
     @Test
     void shouldNotFailWhenErrorsAreWithinThreshold() throws Exception {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 0
@@ -168,6 +172,7 @@ class DetektIntegrationTest {
     @Test
     void shouldNotFailBuildWhenNoDetektWarningsOrErrorsEncounteredAndNoThresholdTrespassed() {
         def testProject = projectRule.newProject()
+                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
                 .withPenalty('''{
                     maxWarnings = 0
                     maxErrors = 0

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -197,7 +197,7 @@ class DetektIntegrationTest {
     }
 
     @Test
-    void shouldFailBuildWhenNoDetektConfiguredButNotApplied() {
+    void shouldFailBuildWhenDetektConfiguredButNotApplied() {
         def testProject = projectRule.newProject()
                 .withPenalty('''{
                     maxWarnings = 0

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -42,20 +42,7 @@ class DetektIntegrationTest {
                     maxErrors = 0
                 }''')
 
-        def detektConfiguration = """
-        detekt { 
-            profile('main') { 
-                config = "${Fixtures.Detekt.RULES}" 
-                output = "${testProject.projectDir()}/build/reports"
-                // The input just needs to be configured for the tests. 
-                // Probably detekt doesn't pick up the changed source sets. 
-                // In a example project it was not needed.
-                input = "${Fixtures.Detekt.SOURCES_WITH_WARNINGS}"
-            }
-        }
-        """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
+        testProject = testProject.withToolsConfig(detektConfiguration(testProject, Fixtures.Detekt.SOURCES_WITH_WARNINGS))
 
         TestProject.Result result = testProject
                 .buildAndFail('check')
@@ -75,17 +62,7 @@ class DetektIntegrationTest {
                     maxErrors = 0
                 }''')
 
-        def detektConfiguration = """
-        detekt { 
-            profile('main') { 
-                config = "${Fixtures.Detekt.RULES}" 
-                output = "${testProject.projectDir()}/build/reports"
-                input = "${Fixtures.Detekt.SOURCES_WITH_ERRORS}"
-            }
-        }
-        """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
+        testProject = testProject.withToolsConfig(detektConfiguration(testProject, Fixtures.Detekt.SOURCES_WITH_ERRORS))
 
         TestProject.Result result = testProject
                 .buildAndFail('check')
@@ -121,17 +98,7 @@ class DetektIntegrationTest {
                     maxErrors = 0
                 }''')
 
-        def detektConfiguration = """
-        detekt { 
-            profile('main') { 
-                config = "${Fixtures.Detekt.RULES}" 
-                output = "${testProject.projectDir()}/build/reports"
-                input = "${Fixtures.Detekt.SOURCES_WITH_WARNINGS}"
-            }
-        }
-        """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
+        testProject = testProject.withToolsConfig(detektConfiguration(testProject, Fixtures.Detekt.SOURCES_WITH_WARNINGS))
 
         TestProject.Result result = testProject
                 .build('check')
@@ -150,17 +117,7 @@ class DetektIntegrationTest {
                     maxErrors = 1
                 }''')
 
-        def detektConfiguration = """
-        detekt { 
-            profile('main') { 
-                config = "${Fixtures.Detekt.RULES}" 
-                output = "${testProject.projectDir()}/build/reports"
-                input = "${Fixtures.Detekt.SOURCES_WITH_ERRORS}"
-            }
-        }
-        """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
+        testProject = testProject.withToolsConfig(detektConfiguration(testProject, Fixtures.Detekt.SOURCES_WITH_ERRORS))
 
         TestProject.Result result = testProject
                 .build('check')
@@ -177,17 +134,7 @@ class DetektIntegrationTest {
                     maxWarnings = 0
                     maxErrors = 0
                 }''')
-
-        def detektConfiguration = """
-        detekt { 
-            profile('main') { 
-                config = "${Fixtures.Detekt.RULES}" 
-                output = "${testProject.projectDir()}/build/reports"
-            }
-        }
-        """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
+        testProject = testProject.withToolsConfig(detektConfigurationWithoutInput(testProject))
 
         TestProject.Result result = testProject
                 .build('check')
@@ -204,7 +151,31 @@ class DetektIntegrationTest {
                     maxErrors = 0
                 }''')
 
-        def detektConfiguration = """
+        testProject = testProject.withToolsConfig(detektConfiguration(testProject, Fixtures.Detekt.SOURCES_WITH_ERRORS))
+
+        TestProject.Result result = testProject
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsDetektNotApplied()
+    }
+
+    private static GString detektConfiguration(TestProject testProject, File input) {
+        """
+        detekt { 
+            profile('main') { 
+                config = "${Fixtures.Detekt.RULES}" 
+                output = "${testProject.projectDir()}/build/reports"
+                // The input just needs to be configured for the tests. 
+                // Probably detekt doesn't pick up the changed source sets. 
+                // In a example project it was not needed.
+                input = "${input}"
+            }
+        }
+        """
+    }
+
+    private static GString detektConfigurationWithoutInput(TestProject testProject) {
+        """
         detekt { 
             profile('main') { 
                 config = "${Fixtures.Detekt.RULES}" 
@@ -212,12 +183,5 @@ class DetektIntegrationTest {
             }
         }
         """
-
-        testProject = testProject.withToolsConfig(detektConfiguration)
-
-        TestProject.Result result = testProject
-                .buildAndFail('check')
-
-        assertThat(result.logs).containsDetektNotApplied()
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -195,4 +195,29 @@ class DetektIntegrationTest {
         assertThat(result.logs).doesNotContainLimitExceeded()
         assertThat(result.logs).doesNotContainDetektViolations()
     }
+
+    @Test
+    void shouldFailBuildWhenNoDetektConfiguredButNotApplied() {
+        def testProject = projectRule.newProject()
+                .withPenalty('''{
+                    maxWarnings = 0
+                    maxErrors = 0
+                }''')
+
+        def detektConfiguration = """
+        detekt { 
+            profile('main') { 
+                config = "${Fixtures.Detekt.RULES}" 
+                output = "${testProject.projectDir()}/build/reports"
+            }
+        }
+        """
+
+        testProject = testProject.withToolsConfig(detektConfiguration)
+
+        TestProject.Result result = testProject
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsDetektNotApplied()
+    }
 }

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -13,6 +13,7 @@ import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
+    private static final String DETEKT_NOT_APPLIED = "The Detekt plugin is configured but not applied. Please apply the plugin in your build script."
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle violations found"
     private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
     private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"
@@ -38,6 +39,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
 
     private StringSubject getOutputSubject() {
         check().that(actual().output)
+    }
+
+    public void containsDetektNotApplied() {
+        outputSubject.contains(DETEKT_NOT_APPLIED)
     }
 
     public void doesNotContainLimitExceeded() {

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -13,7 +13,7 @@ import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
-    private static final String DETEKT_NOT_APPLIED = "The Detekt plugin is configured but not applied. Please apply the plugin in your build script."
+    private static final String DETEKT_NOT_APPLIED = "The detekt plugin is configured but not applied. Please apply the plugin in your build script."
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle violations found"
     private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
     private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -13,7 +13,7 @@ import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
-    private static final String DETEKT_NOT_APPLIED = "The detekt plugin is configured but not applied. Please apply the plugin in your build script."
+    private static final String DETEKT_NOT_APPLIED = "The detekt plugin is configured but not applied. Please apply the plugin in your build script For more information see https://github.com/arturbosch/detekt."
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle violations found"
     private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
     private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"

--- a/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
@@ -7,13 +7,9 @@ final class TestKotlinProject extends TestProject<TestKotlinProject> {
 buildscript {
     repositories { 
         jcenter()
-         maven {
-            url "https://plugins.gradle.org/m2/"
-         }
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.10'
-        classpath 'gradle.plugin.io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0.RC6-2'
     }
 }
 

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -85,15 +85,8 @@ ${project.additionalConfiguration}
     }
 
     public T withPlugin(String plugin, String version = null) {
-        this.plugins.add("id \"$plugin\" ${optionalVersionFrom(version)}")
+        this.plugins.add("id '$plugin' ${version ? "version '$version'" : ""}")
         return this
-    }
-
-    private static String optionalVersionFrom(String version) {
-        if (version == null) {
-            return ""
-        }
-        "version \"$version\""
     }
 
 

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -34,7 +34,7 @@ ${project.additionalConfiguration}
                 .withPluginClasspath()
                 .forwardStdOutput(new OutputStreamWriter(System.out))
                 .forwardStdError(new OutputStreamWriter(System.out))
-        withPlugins('com.novoda.static-analysis')
+        withPlugin('com.novoda.static-analysis', null)
     }
 
     private static File createProjectDir(String path) {
@@ -84,14 +84,18 @@ ${project.additionalConfiguration}
         return this
     }
 
-    public T withPlugins(String... plugins) {
-        def formattedPlugins = plugins.collect { plugin ->
-            "id '$plugin'"
-        }.asList()
-
-        this.plugins.addAll(formattedPlugins)
+    public T withPlugin(String plugin, String version) {
+        this.plugins.add("id \"$plugin\" ${optionalVersionFrom(version)}")
         return this
     }
+
+    private static String optionalVersionFrom(String version) {
+        if (version == null) {
+            return ""
+        }
+        "version \"$version\""
+    }
+
 
     public Result build(String... arguments) {
         BuildResult buildResult = newRunner(arguments).build()
@@ -120,7 +124,7 @@ ${project.additionalConfiguration}
         projectDir.deleteDir()
     }
 
-    String projectDir(){
+    String projectDir() {
         return projectDir
     }
 
@@ -129,7 +133,7 @@ ${project.additionalConfiguration}
     }
 
     protected static String formatPlugins(TestProject project) {
-        "${project.plugins.join(',\n')}"
+        "${project.plugins.join('\n')}"
     }
 
     public static class Result {

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -34,7 +34,7 @@ ${project.additionalConfiguration}
                 .withPluginClasspath()
                 .forwardStdOutput(new OutputStreamWriter(System.out))
                 .forwardStdError(new OutputStreamWriter(System.out))
-        withPlugin('com.novoda.static-analysis', null)
+        withPlugin('com.novoda.static-analysis')
     }
 
     private static File createProjectDir(String path) {
@@ -84,7 +84,7 @@ ${project.additionalConfiguration}
         return this
     }
 
-    public T withPlugin(String plugin, String version) {
+    public T withPlugin(String plugin, String version = null) {
         this.plugins.add("id \"$plugin\" ${optionalVersionFrom(version)}")
         return this
     }


### PR DESCRIPTION
[PT-498](https://novoda.atlassian.net/browse/PT-498)
### Description
We agreed [here](https://novoda.atlassian.net/browse/PT-496) to expect the user to apply the detekt plugin manually.

This PR will make the build fail and give the user a hint to apply the detekt plugin manually in case it's configured but not applied.

### Details
- throw an exception in case the detekt plugin is configured but not applied

### Tests
- changed the `TestKotlinProject` to not contain the detekt plugin per default
- apply the plugin in existing tests 
- add a test which verifies we fail gracefully in case the detekt plugin is configured but not applied