### PR TITLE
[PT-495] Support android kotlin projects

### DIFF
--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -22,7 +22,7 @@ class DetektIntegrationTest {
 
     @Parameterized.Parameters(name = "{0}")
     static Iterable<TestProjectRule> rules() {
-        return [TestProjectRule.forKotlinProject()]
+        return [TestProjectRule.forKotlinProject(), TestProjectRule.forAndroidKotlinProject()]
     }
 
     @Rule

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -1,0 +1,78 @@
+package com.novoda.test
+
+class TestAndroidKotlinProject extends TestProject<TestAndroidKotlinProject> {
+    private static final Closure<String> TEMPLATE = { TestAndroidKotlinProject project ->
+        """
+buildscript {
+    repositories { 
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'  
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
+    }
+}
+plugins {
+    ${formatPlugins(project)}
+}
+repositories { 
+    google()
+    jcenter()
+}
+apply plugin: 'com.android.library'  
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 27
+        versionCode 1
+        versionName '1.0'
+    }
+    sourceSets {
+        ${formatSourceSets(project)}
+    }
+    ${project.additionalAndroidConfig}
+}
+${formatExtension(project)}
+"""
+    }
+
+    private String additionalAndroidConfig = ''
+
+    TestAndroidKotlinProject() {
+        super(TEMPLATE)
+        File localProperties = Fixtures.LOCAL_PROPERTIES
+        if (localProperties.exists()) {
+            withFile(localProperties, 'local.properties')
+        }
+    }
+
+    private static String formatSourceSets(TestProject project) {
+        project.sourceSets
+                .entrySet()
+                .collect { Map.Entry<String, List<String>> entry ->
+            """$entry.key {
+            manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
+            java {
+                ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
+            }
+        }"""
+        }
+        .join('\n\t\t')
+    }
+
+    @Override
+    List<String> defaultArguments() {
+        ['-x', 'lint'] + super.defaultArguments()
+    }
+
+    TestAndroidKotlinProject withAdditionalAndroidConfig(String additionalAndroidConfig) {
+        this.additionalAndroidConfig = additionalAndroidConfig
+        return this
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -4,23 +4,23 @@ class TestAndroidKotlinProject extends TestProject<TestAndroidKotlinProject> {
     private static final Closure<String> TEMPLATE = { TestAndroidKotlinProject project ->
         """
 buildscript {
-    repositories { 
+    repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'  
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
     }
 }
 plugins {
     ${formatPlugins(project)}
 }
-repositories { 
+repositories {
     google()
     jcenter()
 }
-apply plugin: 'com.android.library'  
+apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -58,7 +58,7 @@ ${formatExtension(project)}
                 .collect { Map.Entry<String, List<String>> entry ->
             """$entry.key {
             manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
-            java {
+            kotlin {
                 ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
             }
         }"""

--- a/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
@@ -20,7 +20,7 @@ final class TestProjectRule<T extends TestProject> implements TestRule {
     }
 
     static TestProjectRule<TestAndroidKotlinProject> forAndroidKotlinProject() {
-        new TestProjectRule({ new TestAndroidKotlinProject() }, { String name -> "project.android.sourceSets.$name" }, 'Android project')
+        new TestProjectRule({ new TestAndroidKotlinProject() }, { String name -> "project.android.sourceSets.$name" }, 'Android kotlin project')
     }
 
     static TestProjectRule<TestKotlinProject> forKotlinProject() {

--- a/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
@@ -19,6 +19,10 @@ final class TestProjectRule<T extends TestProject> implements TestRule {
         new TestProjectRule({ new TestAndroidProject() }, { String name -> "project.android.sourceSets.$name" }, 'Android project')
     }
 
+    static TestProjectRule<TestAndroidKotlinProject> forAndroidKotlinProject() {
+        new TestProjectRule({ new TestAndroidKotlinProject() }, { String name -> "project.android.sourceSets.$name" }, 'Android project')
+    }
+
     static TestProjectRule<TestKotlinProject> forKotlinProject() {
         new TestProjectRule({ new TestKotlinProject() }, { String name -> "project.sourceSets.$name" }, 'Kotlin project')
     }


### PR DESCRIPTION
[PT-495](https://novoda.atlassian.net/browse/PT-495)

### Description
Scope of this PR is to add to make sure the detekt integration works also with android kotlin projects. Turned out that this works out of the box, so this PR just modifies the tests to consider also android kotlin projects.

### Tests
- created `TestAndroidKotlinProject`
- changed `DetektIntegrationTest` to run all existing tests also against a `TestAndroidKotlinProject`