### PR TITLE
[PT-503] Detekt Integration Bugs

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
@@ -27,7 +27,7 @@ abstract class CollectViolationsTask extends DefaultTask {
 
     @TaskAction
     final void run() {
-        collectViolations(xmlReportFile, htmlReportFile, violations)
+        collectViolations(getXmlReportFile(), getHtmlReportFile(), violations)
     }
 
     File getXmlReportFile() {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.TaskAction
 abstract class CollectViolationsTask extends DefaultTask {
 
     private File xmlReportFile
+    private File htmlReportFile
     private Violations violations
 
     CollectViolationsTask() {
@@ -14,6 +15,10 @@ abstract class CollectViolationsTask extends DefaultTask {
 
     void setXmlReportFile(File xmlReportFile) {
         this.xmlReportFile = xmlReportFile
+    }
+
+    void setHtmlReportFile(File htmlReportFile) {
+        this.htmlReportFile = htmlReportFile
     }
 
     void setViolations(Violations violations) {
@@ -30,7 +35,7 @@ abstract class CollectViolationsTask extends DefaultTask {
     }
 
     File getHtmlReportFile() {
-        new File(xmlReportFile.absolutePath - '.xml' + '.html')
+        htmlReportFile ?: new File(xmlReportFile.absolutePath - '.xml' + '.html')
     }
 
     abstract void collectViolations(File xmlReportFile, File htmlReportFile, Violations violations)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -65,9 +65,10 @@ class DetektConfigurator implements Configurator {
     }
 
     private CollectDetektViolationsTask createCollectViolationsTask(Violations violations) {
-        def reportFilePath = "${project.extensions.findByName('detekt').systemOrDefaultProfile().output}/detekt-checkstyle.xml"
+        def outputFolder = project.file(project.extensions.findByName('detekt').systemOrDefaultProfile().output)
         project.tasks.create("collectDetektViolations", CollectDetektViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = project.file(reportFilePath)
+            collectViolations.xmlReportFile = new File(outputFolder, 'detekt-checkstyle.xml')
+            collectViolations.htmlReportFile = new File(outputFolder, 'detekt-report.html')
             collectViolations.violations = violations
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -66,9 +66,8 @@ class DetektConfigurator implements Configurator {
 
     private CollectDetektViolationsTask createCollectViolationsTask(Violations violations) {
         def reportFilePath = "${project.extensions.findByName('detekt').systemOrDefaultProfile().output}/detekt-checkstyle.xml"
-
         project.tasks.create("collectDetektViolations", CollectDetektViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = new File(reportFilePath)
+            collectViolations.xmlReportFile = project.file(reportFilePath)
             collectViolations.violations = violations
         }
     }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -39,7 +39,7 @@ class DetektIntegrationTest {
 
         assertThat(result.logs).containsLimitExceeded(0, 1)
         assertThat(result.logs).containsDetektViolations(0, 1,
-                result.buildFileUrl('reports/detekt-checkstyle.html'))
+                result.buildFileUrl('reports/detekt-report.html'))
     }
 
     @Test
@@ -49,7 +49,7 @@ class DetektIntegrationTest {
 
         assertThat(result.logs).containsLimitExceeded(1, 0)
         assertThat(result.logs).containsDetektViolations(1, 0,
-                result.buildFileUrl('reports/detekt-checkstyle.html'))
+                result.buildFileUrl('reports/detekt-report.html'))
     }
 
     @Test
@@ -66,7 +66,7 @@ class DetektIntegrationTest {
                 .build('check')
 
         assertThat(result.logs).containsDetektViolations(0, 1,
-                result.buildFileUrl('reports/detekt-checkstyle.html'))
+                result.buildFileUrl('reports/detekt-report.html'))
     }
 
     @Test
@@ -75,7 +75,7 @@ class DetektIntegrationTest {
                 .build('check')
 
         assertThat(result.logs).containsDetektViolations(1, 0,
-                result.buildFileUrl('reports/detekt-checkstyle.html'))
+                result.buildFileUrl('reports/detekt-report.html'))
     }
 
     @Test


### PR DESCRIPTION
[PT-503](https://novoda.atlassian.net/browse/PT-503)

### Description
While testing the integration in the wild we found two bugs:
- the detekt reports are not picked up for evaluation
- the link to the html report is wrong

### Considerations
- generate path to report file by using `project.file()` with the relative path. This was working in the tests since we are using an absolute path
- make `htmlReportFile` configurable since detekt names the html report different than the xml report.

### Tests
- added a test to verify the link to the html report is correct

Paired with @tasomaniac 