### PR TITLE
[PT-511] Configure lint via SAP extension

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -5,6 +5,7 @@ import com.novoda.staticanalysis.internal.Violations
 import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
 import com.novoda.staticanalysis.internal.detekt.DetektConfigurator
 import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator
+import com.novoda.staticanalysis.internal.lint.LintConfigurator
 import com.novoda.staticanalysis.internal.pmd.PmdConfigurator
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
@@ -39,7 +40,8 @@ class StaticAnalysisPlugin implements Plugin<Project> {
                 CheckstyleConfigurator.create(project, violationsContainer, evaluateViolations),
                 PmdConfigurator.create(project, violationsContainer, evaluateViolations),
                 FindbugsConfigurator.create(project, violationsContainer, evaluateViolations),
-                DetektConfigurator.create(project, violationsContainer, evaluateViolations)
+                DetektConfigurator.create(project, violationsContainer, evaluateViolations),
+                LintConfigurator.create(project, violationsContainer, evaluateViolations)
         ]
     }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
@@ -1,0 +1,13 @@
+package com.novoda.staticanalysis.internal.lint
+
+import com.novoda.staticanalysis.internal.CollectViolationsTask
+import com.novoda.staticanalysis.internal.Violations
+
+class CollectLintViolationsTask extends CollectViolationsTask {
+
+    @Override
+    void collectViolations(File xmlReportFile, File htmlReportFile, Violations violations) {
+        //TODO: collect lint violations
+    }
+
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
@@ -2,12 +2,16 @@ package com.novoda.staticanalysis.internal.lint
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.internal.Violations
+import groovy.util.slurpersupport.GPathResult
 
 class CollectLintViolationsTask extends CollectViolationsTask {
 
     @Override
     void collectViolations(File xmlReportFile, File htmlReportFile, Violations violations) {
-        //TODO: collect lint violations
+        GPathResult xml = new XmlSlurper().parse(xmlReportFile)
+        int errors = xml.'**'.findAll { node -> node.name() == 'issue' && node.@severity == 'Error' }.size()
+        int warnings = xml.'**'.findAll { node -> node.name() == 'issue' && node.@severity == 'Warning' }.size()
+        violations.addViolations(errors, warnings, htmlReportFile ?: xmlReportFile)
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -48,7 +48,7 @@ class LintConfigurator implements Configurator {
 
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
         def outputFolder = new File(project.projectDir, 'build/reports')
-        project.tasks.create("collectLintViolations", CollectLintViolationsTask) { collectViolations ->
+        project.tasks.create('collectLintViolations', CollectLintViolationsTask) { collectViolations ->
             collectViolations.xmlReportFile = new File(outputFolder, 'lint-results.xml')
             collectViolations.htmlReportFile = new File(outputFolder, 'lint-results.html')
             collectViolations.violations = violations

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -50,8 +50,8 @@ class LintConfigurator implements Configurator {
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
         def outputFolder = new File(project.projectDir, 'build/reports')
         project.tasks.create("collectLintViolations", CollectLintViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = new File(outputFolder, 'lint-report.xml')
-            collectViolations.htmlReportFile = new File(outputFolder, 'lint-report.html')
+            collectViolations.xmlReportFile = new File(outputFolder, 'lint-results.xml')
+            collectViolations.htmlReportFile = new File(outputFolder, 'lint-results.html')
             collectViolations.violations = violations
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -48,7 +48,6 @@ class LintConfigurator implements Configurator {
     }
 
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
-//        def outputFolder = project.file(project.extensions.findByName('android').lintOptions.xmlOutput.parent)
         def outputFolder = new File(project.projectDir, 'build/reports')
         project.tasks.create("collectLintViolations", CollectLintViolationsTask) { collectViolations ->
             collectViolations.xmlReportFile = new File(outputFolder, 'lint-report.xml')

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -66,7 +66,7 @@ class LintConfigurator implements Configurator {
     }
 
     private File getDefaultOutputFolder() {
-        new File(project.projectDir, 'build/reports')
+        new File(project.buildDir, 'reports')
     }
 
     private static boolean isAndroidProject(final Project project) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -48,7 +48,8 @@ class LintConfigurator implements Configurator {
     }
 
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
-        def outputFolder = project.file(project.extensions.findByName('android').lintOptions.xmlOutput.parent)
+//        def outputFolder = project.file(project.extensions.findByName('android').lintOptions.xmlOutput.parent)
+        def outputFolder = new File(project.projectDir, 'build/reports')
         project.tasks.create("collectLintViolations", CollectLintViolationsTask) { collectViolations ->
             collectViolations.xmlReportFile = new File(outputFolder, 'lint-report.xml')
             collectViolations.htmlReportFile = new File(outputFolder, 'lint-report.html')

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -54,12 +54,19 @@ class LintConfigurator implements Configurator {
     }
 
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
-        def outputFolder = new File(project.projectDir, 'build/reports')
         project.tasks.create('collectLintViolations', CollectLintViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = new File(outputFolder, 'lint-results.xml')
-            collectViolations.htmlReportFile = new File(outputFolder, 'lint-results.html')
+            collectViolations.xmlReportFile = xmlOutputFile()
+            collectViolations.htmlReportFile = new File(defaultOutputFolder(), 'lint-results.html')
             collectViolations.violations = violations
         }
+    }
+
+    private File xmlOutputFile() {
+        project.android.lintOptions.xmlOutput ?: new File(defaultOutputFolder(), 'lint-results.xml')
+    }
+
+    private File defaultOutputFolder() {
+        new File(project.projectDir, 'build/reports')
     }
 
     private static boolean isAndroidProject(final Project project) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -41,6 +41,7 @@ class LintConfigurator implements Configurator {
         project.android.lintOptions(config)
         project.android.lintOptions {
             xmlReport = true
+            htmlReport = true
             abortOnError false
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -34,7 +34,7 @@ class LintConfigurator implements Configurator {
                 return
             }
 
-            project.extensions.findByName('android').lintOptions(config)
+            project.android.lintOptions(config)
 
             configureToolTask()
         }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -29,7 +29,6 @@ class LintConfigurator implements Configurator {
     @Override
     void execute() {
         project.extensions.findByType(StaticAnalysisExtension).ext."lintOptions" = { Closure config ->
-
             if (!isAndroidProject(project)) {
                 return
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -1,0 +1,64 @@
+package com.novoda.staticanalysis.internal.lint
+
+import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.internal.Configurator
+import com.novoda.staticanalysis.internal.Violations
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+class LintConfigurator implements Configurator {
+
+    private final Project project
+    private final Violations violations
+    private final Task evaluateViolations
+
+    static LintConfigurator create(Project project,
+                                   NamedDomainObjectContainer<Violations> violationsContainer,
+                                   Task evaluateViolations) {
+        Violations violations = violationsContainer.maybeCreate('Lint')
+        return new LintConfigurator(project, violations, evaluateViolations)
+    }
+
+    private LintConfigurator(Project project, Violations violations, Task evaluateViolations) {
+        this.project = project
+        this.violations = violations
+        this.evaluateViolations = evaluateViolations
+    }
+
+    @Override
+    void execute() {
+        project.extensions.findByType(StaticAnalysisExtension).ext."lintOptions" = { Closure config ->
+
+            if (!isAndroidProject(project)) {
+                return
+            }
+
+            project.extensions.findByName('android').lintOptions(config)
+
+            configureToolTask()
+        }
+    }
+
+    private void configureToolTask() {
+        // evaluate violations after lint
+        def collectViolations = createCollectViolationsTask(violations)
+        evaluateViolations.dependsOn collectViolations
+        collectViolations.dependsOn project.tasks['lint']
+    }
+
+    private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
+        def outputFolder = project.file(project.extensions.findByName('android').lintOptions.xmlOutput.parent)
+        project.tasks.create("collectLintViolations", CollectLintViolationsTask) { collectViolations ->
+            collectViolations.xmlReportFile = new File(outputFolder, 'lint-report.xml')
+            collectViolations.htmlReportFile = new File(outputFolder, 'lint-report.html')
+            collectViolations.violations = violations
+        }
+    }
+
+    private static boolean isAndroidProject(final Project project) {
+        final boolean isAndroidApplication = project.plugins.hasPlugin('com.android.application')
+        final boolean isAndroidLibrary = project.plugins.hasPlugin('com.android.library')
+        return isAndroidApplication || isAndroidLibrary
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -32,10 +32,16 @@ class LintConfigurator implements Configurator {
             if (!isAndroidProject(project)) {
                 return
             }
-
-            project.android.lintOptions(config)
-
+            configureLint(config)
             configureToolTask()
+        }
+    }
+
+    private void configureLint(Closure config) {
+        project.android.lintOptions(config)
+        project.android.lintOptions {
+            xmlReport = true
+            abortOnError false
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -55,17 +55,17 @@ class LintConfigurator implements Configurator {
 
     private CollectLintViolationsTask createCollectViolationsTask(Violations violations) {
         project.tasks.create('collectLintViolations', CollectLintViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = xmlOutputFile()
-            collectViolations.htmlReportFile = new File(defaultOutputFolder(), 'lint-results.html')
+            collectViolations.xmlReportFile = xmlOutputFile
+            collectViolations.htmlReportFile = new File(defaultOutputFolder, 'lint-results.html')
             collectViolations.violations = violations
         }
     }
 
-    private File xmlOutputFile() {
-        project.android.lintOptions.xmlOutput ?: new File(defaultOutputFolder(), 'lint-results.xml')
+    private File getXmlOutputFile() {
+        project.android.lintOptions.xmlOutput ?: new File(defaultOutputFolder, 'lint-results.xml')
     }
 
-    private File defaultOutputFolder() {
+    private File getDefaultOutputFolder() {
         new File(project.projectDir, 'build/reports')
     }
 

--- a/plugin/src/test/fixtures/reports/lint/lint-results.xml
+++ b/plugin/src/test/fixtures/reports/lint/lint-results.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.0.1">
+
+    <issue
+        id="MissingSuperCall"
+        severity="Error"
+        message="Overriding method should call `super.onDetachedFromWindow`"
+        category="Correctness"
+        priority="9"
+        summary="Missing Super Call"
+        explanation="Some methods, such as `View#onDetachedFromWindow`, require that you also call the super&#xA;implementation as part of your method."
+        errorLine1="    protected void onDetachedFromWindow() {"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="/Users/tobiasheine/Documents/repos/gradle-static-analysis-plugin/plugin/src/test/fixtures/sources/lint/errors/MyView.java"
+            line="13"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="Assert"
+        severity="Warning"
+        message="Assertions are unreliable in Dalvik and unimplemented in ART. Use `BuildConfig.DEBUG` conditional checks instead."
+        category="Correctness"
+        priority="6"
+        summary="Assertions"
+        explanation="Assertions are not checked at runtime. There are ways to request that they be used by Dalvik \&#xA;(`adb shell setprop debug.assert 1`), but note that this is not implemented in ART (the newer \&#xA;runtime), and even in Dalvik the property is ignored in many places and can not be relied upon. \&#xA;Instead, perform conditional checking inside `if (BuildConfig.DEBUG) { }` blocks. That constant \&#xA;is a static final boolean which is true in debug builds and false in release builds, and the \&#xA;Java compiler completely removes all code inside the if-body from the app.&#xA;&#xA;For example, you can replace `assert speed > 0` with `if (BuildConfig.DEBUG &amp;&amp; !(speed > 0)) { \&#xA;throw new AssertionError() }`.&#xA;&#xA;(Note: This lint check does not flag assertions purely asserting nullness or non-nullness; these \&#xA;are typically more intended for tools usage than runtime checks.)"
+        url="https://code.google.com/p/android/issues/detail?id=65183"
+        urls="https://code.google.com/p/android/issues/detail?id=65183"
+        errorLine1="        assert false;"
+        errorLine2="        ~~~~~~">
+        <location
+            file="/Users/tobiasheine/Documents/repos/gradle-static-analysis-plugin/plugin/src/test/fixtures/sources/lint/warnings/Warning.java"
+            line="6"
+            column="9"/>
+    </issue>
+</issues>

--- a/plugin/src/test/fixtures/rules/lint/lint.xml
+++ b/plugin/src/test/fixtures/rules/lint/lint.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+  <!-- Disable the given check in this project -->
+  <issue id="IconMissingDensityFolder" severity="ignore" />
+
+  <!-- Ignore the ObsoleteLayoutParam issue in the specified files -->
+  <issue id="ObsoleteLayoutParam">
+    <ignore path="res/layout/activation.xml" />
+    <ignore path="res/layout-xlarge/activation.xml" />
+  </issue>
+
+  <!-- Ignore the UselessLeaf issue in the specified file -->
+  <issue id="UselessLeaf">
+    <ignore path="res/layout/main.xml" />
+  </issue>
+
+  <!-- Change the severity of hardcoded strings to "error" -->
+  <issue id="HardcodedText" severity="error" />
+</lint>

--- a/plugin/src/test/fixtures/rules/lint/lint.xml
+++ b/plugin/src/test/fixtures/rules/lint/lint.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
   <!-- Disable the given check in this project -->
-  <issue id="IconMissingDensityFolder" severity="ignore" />
-
-  <!-- Ignore the ObsoleteLayoutParam issue in the specified files -->
-  <issue id="ObsoleteLayoutParam">
-    <ignore path="res/layout/activation.xml" />
-    <ignore path="res/layout-xlarge/activation.xml" />
-  </issue>
-
-  <!-- Ignore the UselessLeaf issue in the specified file -->
-  <issue id="UselessLeaf">
-    <ignore path="res/layout/main.xml" />
-  </issue>
-
-  <!-- Change the severity of hardcoded strings to "error" -->
-  <issue id="HardcodedText" severity="error" />
+  <issue id="GradleDependency" severity="ignore" />
 </lint>

--- a/plugin/src/test/fixtures/sources/lint/errors/MyView.java
+++ b/plugin/src/test/fixtures/sources/lint/errors/MyView.java
@@ -1,0 +1,14 @@
+import android.content.Context;
+import android.view.View;
+
+public class MyView extends View {
+
+    public MyView(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        // missing super call
+    }
+}

--- a/plugin/src/test/fixtures/sources/lint/warnings/Warning.java
+++ b/plugin/src/test/fixtures/sources/lint/warnings/Warning.java
@@ -1,0 +1,7 @@
+public class Warning {
+
+    public Warning() {
+        // assertions are ignored at runtime
+        assert false;
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -1,10 +1,8 @@
 package com.novoda.staticanalysis.internal.detekt
 
-import com.novoda.test.DeployRulesTestRule
 import com.novoda.test.Fixtures
 import com.novoda.test.TestProject
 import com.novoda.test.TestProjectRule
-import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,11 +12,6 @@ import static com.novoda.test.LogsSubject.assertThat
 
 @RunWith(Parameterized.class)
 class DetektIntegrationTest {
-
-    @ClassRule
-    public static final DeployRulesTestRule DEPLOY_RULES = new DeployRulesTestRule(
-            resourceDirs: [Fixtures.RULES_DIR],
-            repoDir: new File(Fixtures.BUILD_DIR, 'rules'))
 
     @Parameterized.Parameters(name = "{0}")
     static Iterable<TestProjectRule> rules() {

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -1,0 +1,23 @@
+package com.novoda.staticanalysis.internal.lint
+
+import com.google.common.truth.Truth
+import com.novoda.staticanalysis.internal.Violations
+import com.novoda.test.Fixtures
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class CollectLintViolationsTaskTest {
+
+    @Test
+    void shouldAddResultsToViolations() throws Exception {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('collectLintViolationsTask', type: CollectLintViolationsTask)
+
+        Violations violations = new Violations("Android Lint")
+        task.collectViolations(Fixtures.Lint.SAMPLE_REPORT, null, violations)
+
+        Truth.assertThat(violations.getErrors()).isEqualTo(1)
+        Truth.assertThat(violations.getWarnings()).isEqualTo(1)
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -15,7 +15,7 @@ class CollectLintViolationsTaskTest {
         Project project = ProjectBuilder.builder().build()
         def task = project.task('collectLintViolationsTask', type: CollectLintViolationsTask)
 
-        Violations violations = new Violations("Android Lint")
+        Violations violations = new Violations('Android Lint')
         task.collectViolations(Fixtures.Lint.SAMPLE_REPORT, null, violations)
 
         assertThat(violations.getErrors()).isEqualTo(1)

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -1,11 +1,12 @@
 package com.novoda.staticanalysis.internal.lint
 
-import com.google.common.truth.Truth
 import com.novoda.staticanalysis.internal.Violations
 import com.novoda.test.Fixtures
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
+
+import static com.google.common.truth.Truth.assertThat
 
 class CollectLintViolationsTaskTest {
 
@@ -17,7 +18,7 @@ class CollectLintViolationsTaskTest {
         Violations violations = new Violations("Android Lint")
         task.collectViolations(Fixtures.Lint.SAMPLE_REPORT, null, violations)
 
-        Truth.assertThat(violations.getErrors()).isEqualTo(1)
-        Truth.assertThat(violations.getWarnings()).isEqualTo(1)
+        assertThat(violations.getErrors()).isEqualTo(1)
+        assertThat(violations.getWarnings()).isEqualTo(1)
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -9,6 +9,14 @@ import static com.novoda.test.LogsSubject.assertThat
 
 class LintIntegrationTest {
 
+    private static GString LINT_CONFIGURATION =
+            """
+        lintOptions {              
+            abortOnError false
+            lintConfig = file("${Fixtures.Lint.RULES}") 
+        }
+        """
+
     @Test
     void shouldFailBuildWhenLintErrorsOverTheThresholds() throws Exception {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 0)
@@ -49,15 +57,7 @@ class LintIntegrationTest {
                     maxErrors = ${maxErrors}
                 }""")
 
-        testProject.withToolsConfig(lintConfiguration())
+        testProject.withToolsConfig(LINT_CONFIGURATION)
     }
 
-    private static GString lintConfiguration() {
-        """
-        lintOptions {              
-            abortOnError false
-            lintConfig = file("${Fixtures.Lint.RULES}") 
-        }
-        """
-    }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -17,6 +17,14 @@ class LintIntegrationTest {
         assertThat(result.logs).containsLintViolations(0, 1)
     }
 
+    @Test
+    void shouldNotFailBuildWhenLintWarningsWithinTheThreshold() throws Exception {
+        def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 1, 0)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+    }
+
     private static TestProject createAndroidProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {
         def testProject = new TestAndroidProject()
                 .withSourceSet('main', sources)

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -10,6 +10,14 @@ import static com.novoda.test.LogsSubject.assertThat
 class LintIntegrationTest {
 
     @Test
+    void shouldFailBuildWhenLintErrorsOverTheThreshold() throws Exception {
+        def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 0)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLintViolations(1, 0, 'reports/lint-results.html')
+    }
+
+    @Test
     void shouldFailBuildWhenLintWarningsOverTheThreshold() throws Exception {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
                 .buildAndFail('check')
@@ -38,7 +46,8 @@ class LintIntegrationTest {
 
     private static GString lintConfiguration() {
         """
-        lintOptions { 
+        lintOptions {              
+            abortOnError false
             lintConfig = file("${Fixtures.Lint.RULES}") 
         }
         """

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -1,0 +1,55 @@
+package com.novoda.staticanalysis.internal.lint
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.LogsSubject.assertThat
+
+@RunWith(Parameterized.class)
+class LintIntegrationTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    static Iterable<TestProjectRule> rules() {
+        return [TestProjectRule.forAndroidProject()]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    LintIntegrationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    void shouldFailBuildWhenLintWarningsOverTheThreshold() throws Exception {
+        def result = createProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLintViolations(0, 1)
+    }
+
+    private TestProject createProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {
+        def testProject = projectRule.newProject()
+                .withSourceSet('main', sources)
+                .withPenalty("""{
+                    maxWarnings = ${maxWarnings}
+                    maxErrors = ${maxErrors}
+                }""")
+
+        testProject.withToolsConfig(lintConfiguration(testProject, sources))
+    }
+
+    private static GString lintConfiguration(TestProject testProject, File input) {
+        """
+        lintOptions { 
+            //lintConfig = file("${Fixtures.Detekt.RULES}") 
+            xmlOutput = "${testProject.projectDir()}/build/reports"
+        }
+        """
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -1,40 +1,24 @@
 package com.novoda.staticanalysis.internal.lint
 
 import com.novoda.test.Fixtures
+import com.novoda.test.TestAndroidProject
 import com.novoda.test.TestProject
-import com.novoda.test.TestProjectRule
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 import static com.novoda.test.LogsSubject.assertThat
 
-@RunWith(Parameterized.class)
 class LintIntegrationTest {
-
-    @Parameterized.Parameters(name = "{0}")
-    static Iterable<TestProjectRule> rules() {
-        return [TestProjectRule.forAndroidProject()]
-    }
-
-    @Rule
-    public final TestProjectRule projectRule
-
-    LintIntegrationTest(TestProjectRule projectRule) {
-        this.projectRule = projectRule
-    }
 
     @Test
     void shouldFailBuildWhenLintWarningsOverTheThreshold() throws Exception {
-        def result = createProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
+        def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLintViolations(0, 1)
     }
 
-    private TestProject createProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {
-        def testProject = projectRule.newProject()
+    private static TestProject createAndroidProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {
+        def testProject = new TestAndroidProject()
                 .withSourceSet('main', sources)
                 .withPenalty("""{
                     maxWarnings = ${maxWarnings}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -31,8 +31,8 @@ class LintIntegrationTest {
     private static GString lintConfiguration(TestProject testProject, File input) {
         """
         lintOptions { 
-            //lintConfig = file("${Fixtures.Detekt.RULES}") 
-            xmlOutput = file("${testProject.projectDir()}/build/reports")
+            lintConfig = file("${Fixtures.Lint.RULES}") 
+            //xmlOutput = file("${testProject.projectDir()}/build/reports")
         }
         """
     }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -12,7 +12,6 @@ class LintIntegrationTest {
     private static GString LINT_CONFIGURATION =
             """
         lintOptions {              
-            abortOnError false
             lintConfig = file("${Fixtures.Lint.RULES}") 
         }
         """

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -10,7 +10,7 @@ import static com.novoda.test.LogsSubject.assertThat
 class LintIntegrationTest {
 
     @Test
-    void shouldFailBuildWhenLintErrorsOverTheThreshold() throws Exception {
+    void shouldFailBuildWhenLintErrorsOverTheThresholds() throws Exception {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 0)
                 .buildAndFail('check')
 
@@ -18,7 +18,15 @@ class LintIntegrationTest {
     }
 
     @Test
-    void shouldFailBuildWhenLintWarningsOverTheThreshold() throws Exception {
+    void shouldNotFailBuildWhenLintErrorsWithinTheThresholds() throws Exception {
+        def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 1)
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+    }
+
+    @Test
+    void shouldFailBuildWhenLintWarningsOverTheThresholds() throws Exception {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
                 .buildAndFail('check')
 
@@ -26,7 +34,7 @@ class LintIntegrationTest {
     }
 
     @Test
-    void shouldNotFailBuildWhenLintWarningsWithinTheThreshold() throws Exception {
+    void shouldNotFailBuildWhenLintWarningsWithinTheThresholds() throws Exception {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 1, 0)
                 .build('check')
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -32,7 +32,7 @@ class LintIntegrationTest {
         """
         lintOptions { 
             //lintConfig = file("${Fixtures.Detekt.RULES}") 
-            xmlOutput = "${testProject.projectDir()}/build/reports"
+            xmlOutput = file("${testProject.projectDir()}/build/reports")
         }
         """
     }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -14,7 +14,7 @@ class LintIntegrationTest {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
                 .buildAndFail('check')
 
-        assertThat(result.logs).containsLintViolations(0, 1)
+        assertThat(result.logs).containsLintViolations(0, 1, 'reports/lint-results.html')
     }
 
     @Test

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -25,14 +25,13 @@ class LintIntegrationTest {
                     maxErrors = ${maxErrors}
                 }""")
 
-        testProject.withToolsConfig(lintConfiguration(testProject, sources))
+        testProject.withToolsConfig(lintConfiguration())
     }
 
-    private static GString lintConfiguration(TestProject testProject, File input) {
+    private static GString lintConfiguration() {
         """
         lintOptions { 
             lintConfig = file("${Fixtures.Lint.RULES}") 
-            //xmlOutput = file("${testProject.projectDir()}/build/reports")
         }
         """
     }

--- a/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -54,6 +54,7 @@ public final class Fixtures {
         public static final File SOURCES_WITH_WARNINGS = new File(SOURCES_DIR, 'lint/warnings')
         public static final File SOURCES_WITH_ERRORS = new File(SOURCES_DIR, 'lint/errors')
         public static final File SAMPLE_REPORT = new File(REPORTS_DIR, 'lint/lint-results.xml')
+        public static final File RULES = new File(RULES_DIR, 'lint/lint.xml')
     }
 
 }

--- a/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -53,6 +53,7 @@ public final class Fixtures {
     final static class Lint {
         public static final File SOURCES_WITH_WARNINGS = new File(SOURCES_DIR, 'lint/warnings')
         public static final File SOURCES_WITH_ERRORS = new File(SOURCES_DIR, 'lint/errors')
+        public static final File SAMPLE_REPORT = new File(REPORTS_DIR, 'lint/lint-results.xml')
     }
 
 }

--- a/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -50,4 +50,9 @@ public final class Fixtures {
         public static final File RULES = new File(RULES_DIR, 'detekt/detekt.yml')
     }
 
+    final static class Lint {
+        public static final File SOURCES_WITH_WARNINGS = new File(SOURCES_DIR, 'lint/warnings')
+        public static final File SOURCES_WITH_ERRORS = new File(SOURCES_DIR, 'lint/errors')
+    }
+
 }

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -70,6 +70,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         outputSubject.doesNotContain(DETEKT_VIOLATIONS_FOUND)
     }
 
+    public void doesNotContainLintViolations() {
+        outputSubject.doesNotContain(LINT_VIOLATIONS_FOUND)
+    }
+
     public void containsCheckstyleViolations(int errors, int warnings, String... reportUrls) {
         containsToolViolations(CHECKSTYLE_VIOLATIONS_FOUND, errors, warnings, reportUrls)
     }

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -18,6 +18,7 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
     private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"
     private static final String DETEKT_VIOLATIONS_FOUND = "Detekt violations found"
+    private static final String LINT_VIOLATIONS_FOUND = "Lint violations found"
     private static final SubjectFactory<LogsSubject, Logs> FACTORY = new SubjectFactory<LogsSubject, Logs>() {
         @Override
         LogsSubject getSubject(FailureStrategy failureStrategy, Logs logs) {
@@ -83,6 +84,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
 
     public void containsDetektViolations(int errors, int warnings, String... reportUrls) {
         containsToolViolations(DETEKT_VIOLATIONS_FOUND, errors, warnings, reportUrls)
+    }
+
+    public void containsLintViolations(int errors, int warnings, String... reportUrls) {
+        containsToolViolations(LINT_VIOLATIONS_FOUND, errors, warnings, reportUrls)
     }
 
     private void containsToolViolations(String template, int errors, int warnings, String... reportUrls) {

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -63,11 +63,6 @@ ${formatExtension(project)}
         .join('\n\t\t')
     }
 
-    @Override
-    List<String> defaultArguments() {
-        ['-x', 'lint'] + super.defaultArguments()
-    }
-
     TestAndroidProject withAdditionalAndroidConfig(String additionalAndroidConfig) {
         this.additionalAndroidConfig = additionalAndroidConfig
         return this

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -22,7 +22,7 @@ repositories {
 apply plugin: 'com.android.library'
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -22,7 +22,7 @@ repositories {
 apply plugin: 'com.android.library'
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
[PT-511](https://novoda.atlassian.net/browse/PT-511)

### Description
Scope of this PR is to add basic support for [Android Lint](https://developer.android.com/studio/write/lint.html) to the SAP plugin.

This targets a feature branch.

### Considerations
- Added `CollectLintViolationsTask` which parses `lint-result.xml` and appends errors and warnings to the violations

- Added `LintConfigurator` which applies the `lintConfig` closure to Lint and orchestrates the tasks

### Tests
- Added a test for the `CollectLintViolationsTask` to verify we parse the `lint-result.xml` correctly
- Added the `LintIntegrationTest` which verifies warnings and errors are considered for the thresholds

Paired with @lgvalle on parts of it