### PR TITLE
Tweak Detekt exception message

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -11,7 +11,7 @@ import org.gradle.api.Task
 class DetektConfigurator implements Configurator {
 
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
-    private static final String DETEKT_NOT_APPLIED = 'The detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
+    private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
 
     private final Project project
     private final Violations violations

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -32,8 +32,7 @@ class DetektConfigurator implements Configurator {
 
     @Override
     void execute() {
-        project.extensions.findByType(StaticAnalysisExtension).ext."detekt" = { Closure config ->
-
+        project.extensions.findByType(StaticAnalysisExtension).ext.'detekt' = { Closure config ->
             if (!isKotlinProject(project)) {
                 return
             }
@@ -66,7 +65,7 @@ class DetektConfigurator implements Configurator {
 
     private CollectDetektViolationsTask createCollectViolationsTask(Violations violations) {
         def outputFolder = project.file(project.extensions.findByName('detekt').systemOrDefaultProfile().output)
-        project.tasks.create("collectDetektViolations", CollectDetektViolationsTask) { collectViolations ->
+        project.tasks.create('collectDetektViolations', CollectDetektViolationsTask) { collectViolations ->
             collectViolations.xmlReportFile = new File(outputFolder, 'detekt-checkstyle.xml')
             collectViolations.htmlReportFile = new File(outputFolder, 'detekt-report.html')
             collectViolations.violations = violations

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -13,12 +13,12 @@ import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
 
-    private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
-    private static final String DETEKT_NOT_APPLIED = "The Detekt plugin is configured but not applied. Please apply the plugin in your build script."
-    private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle violations found"
-    private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
-    private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"
-    private static final String DETEKT_VIOLATIONS_FOUND = "Detekt violations found"
+    private static final String VIOLATIONS_LIMIT_EXCEEDED = 'Violations limit exceeded'
+    private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.'
+    private static final String CHECKSTYLE_VIOLATIONS_FOUND = 'Checkstyle violations found'
+    private static final String PMD_VIOLATIONS_FOUND = 'PMD violations found'
+    private static final String FINDBUGS_VIOLATIONS_FOUND = 'Findbugs violations found'
+    private static final String DETEKT_VIOLATIONS_FOUND = 'Detekt violations found'
 
     private static final SubjectFactory<LogsSubject, Logs> FACTORY = new SubjectFactory<LogsSubject, Logs>() {
         @Override

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -14,7 +14,7 @@ import static com.novoda.test.TestProject.Result.Logs;
 class LogsSubject extends Subject<LogsSubject, Logs> {
 
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
-    private static final String DETEKT_NOT_APPLIED = "The detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more informations see https://github.com/arturbosch/detekt."
+    private static final String DETEKT_NOT_APPLIED = "The Detekt plugin is configured but not applied. Please apply the plugin in your build script."
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle violations found"
     private static final String PMD_VIOLATIONS_FOUND = "PMD violations found"
     private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs violations found"


### PR DESCRIPTION
This continues with what was supposed to be done in #53, before it was prematurely merged: fixing some more typos and nitpicks, and fixing the tests. Turns out newlines in gradle output cannot be easily captured with a `contains()` assertion because of Gradle's indentations, so I chopped the text we're looking for.