### PR TITLE
Minor document update

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -96,4 +96,4 @@ staticAnalysis {
 }
 ```
 
-Please note that this is not supported for Detekt yet.
+Please note that this is not supported for Detekt & Android Lint yet.


### PR DESCRIPTION
Although we should, `includeVariants` is not supported by lint just now.