### PR TITLE
Add documentation for custom evaluators

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -28,6 +28,9 @@ Violations are then collected while running all the static analysis tools enable
 Only in the end they are cumulatively evaluated against the thresholds provided in the configuration to decide whether the build should
 fail or not.
 
+If you don't specify a `penalty` configuration, the plugin will use the [default threshold values][penaltyextensioncode], which are to
+allow any warning, but break the build on any error.
+
 ## Improve the report with a base URL
 Build logs will show an overall report of how many violations have been found during the analysis and the links to
 the relevant HTML reports, for instance:
@@ -98,3 +101,5 @@ staticAnalysis {
 ```
 
 Please note that this is not supported for Detekt yet.
+
+[penaltyextensioncode]: https://github.com/novoda/gradle-static-analysis-plugin/blob/master/plugin/src/main/groovy/com/novoda/staticanalysis/PenaltyExtension.groovy

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -8,6 +8,7 @@ the build will not fail, which is very useful for legacy projects.
  * [Improve the report with a base URL](#improve-the-report-with-a-base-URL)
  * [Add exclusions with `exclude` filters](#add-exclusions-with-exclude-filters)
  * [Add exclusions with Android build variants](#add-exclusions-with-Android-build-variants)
+ * [Custom violations evaluator (**incubating**)](incubating/custom-evaluator.md#custom-violations-evaluator-incubating)
 
 ---
 

--- a/docs/incubating/custom-evaluator.md
+++ b/docs/incubating/custom-evaluator.md
@@ -1,0 +1,70 @@
+# Custom violations evaluator (incubating)
+
+> Since: [`0.5.1`](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.5.1)
+>
+> :warning: This is an **experimental**, incubating feature that may be subject to breaking API changes at any time!
+
+The plugin uses a [`ViolationsEvaluator`][violationsevaluatorcode] to determine what to do with the results collected from all the active
+tools (if any). The built-in behaviour is provided by the [`DefaultViolationsEvaluator`][defaultviolationsevaluatorcode], which you can
+read more about [below](#the-defaultviolationsevaluator). The plugin's violations evaluation behaviour is not fixed, and it can be
+customised by providing an implementation of the [`ViolationsEvaluator`][violationsevaluatorcode] interface.
+
+## Table of contents
+ * [The `DefaultViolationsEvaluator`](#the-defaultviolationsevaluator)
+ * [Creating a custom violations evaluator](#creating-a-custom-violations-evaluator)
+
+---
+
+## The `DefaultViolationsEvaluator`
+The plugin has a default mechanism to decide whether to consider a build as passing or failed. The mechanism is manifesting itself
+as the `penalties` closure:
+
+```gradle
+staticAnalysis {
+    penalties {
+        maxErrors = 0
+        maxWarnings = 10
+    }
+    //...
+}
+```
+
+This closure instructs the plugin to use a [`DefaultViolationsEvaluator`][defaultviolationsevaluatorcode] that will count the number of
+errors and warnings and compare them against the set thresholds. For more details, see the
+[Configurable failure thresholds](../advanced-usage.md#configurable-failure-thresholds) documentation.
+
+## Creating a custom violations evaluator
+In order to provide a custom evaluator, you can implement the [`ViolationsEvaluator`][violationsevaluatorcode] interface and provide
+that implementation to the `evaluator` property of the `staticAnalysis` closure. The [`ViolationsEvaluator`][violationsevaluatorcode]
+can be provided as a closure as well:
+
+```gradle
+staticAnalysis {
+	evaluator {	Set<Violations> allViolations ->
+       // add your evaluation logic here
+	}
+	//...
+}
+```
+
+The `evaluator` is invoked after all the `collectViolations` tasks have been completed, and is the last step in executing the plugin's
+main task, `evaluateViolations`.
+
+The evaluation logic can be any arbitrary function that respects this contract:
+ * The evaluator receives a set containing all the [`Violations`][violationscode] that have been collected by the tools (one per tool)
+ * If the build is to be considered successful, then the evaluator will run to completion without throwing exceptions
+ * If the build is to be considered failed, then the evaluator will throw a `GradleException`
+
+Anything that respect such contract is valid. For example, a custom evaluator might:
+ * Collect all the report files and upload them somewhere, or send them to Slack or an email address
+ * Use the GitHub API to report the issues on the PR that the build is running on, à la [GNAG](https://github.com/btkelly/gnag)
+ * Only break the build if there's errors or warnings in one specific report
+ * Or anything else that you can think of
+
+Please note that the presence of an `evaluator` property will make the plugin ignore the `penalties` closure and its thresholds. If you
+want to provide behaviour on top of the default [`DefaultViolationsEvaluator`][defaultviolationsevaluatorcode], you can have your own
+evaluator run its logic and then delegate the thresholds counting to an instance of `DefaultViolationsEvaluator` you create.
+
+[violationsevaluatorcode]: https://github.com/novoda/gradle-static-analysis-plugin/blob/master/plugin/src/main/groovy/com/novoda/staticanalysis/ViolationsEvaluator.groovy
+[defaultviolationsevaluatorcode]: https://github.com/novoda/gradle-static-analysis-plugin/blob/master/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
+[violationscode]: https://github.com/novoda/gradle-static-analysis-plugin/blob/master/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy

--- a/docs/incubating/custom-evaluator.md
+++ b/docs/incubating/custom-evaluator.md
@@ -40,10 +40,10 @@ can be provided as a closure as well:
 
 ```gradle
 staticAnalysis {
-	evaluator {	Set<Violations> allViolations ->
+    evaluator { Set<Violations> allViolations ->
        // add your evaluation logic here
-	}
-	//...
+    }
+    //...
 }
 ```
 

--- a/docs/incubating/custom-evaluator.md
+++ b/docs/incubating/custom-evaluator.md
@@ -17,11 +17,11 @@ customised by providing an implementation of the [`ViolationsEvaluator`][violati
 
 ## The `DefaultViolationsEvaluator`
 The plugin has a default mechanism to decide whether to consider a build as passing or failed. The mechanism is manifesting itself
-as the `penalties` closure:
+as the `penalty` closure:
 
 ```gradle
 staticAnalysis {
-    penalties {
+    penalty {
         maxErrors = 0
         maxWarnings = 10
     }
@@ -61,7 +61,7 @@ Anything that respect such contract is valid. For example, a custom evaluator mi
  * Only break the build if there's errors or warnings in one specific report
  * Or anything else that you can think of
 
-Please note that the presence of an `evaluator` property will make the plugin ignore the `penalties` closure and its thresholds. If you
+Please note that the presence of an `evaluator` property will make the plugin ignore the `penalty` closure and its thresholds. If you
 want to provide behaviour on top of the default [`DefaultViolationsEvaluator`][defaultviolationsevaluatorcode], you can have your own
 evaluator run its logic and then delegate the thresholds counting to an instance of `DefaultViolationsEvaluator` you create.
 

--- a/docs/incubating/custom-evaluator.md
+++ b/docs/incubating/custom-evaluator.md
@@ -58,7 +58,7 @@ The evaluation logic can be any arbitrary function that respects this contract:
 Anything that respect such contract is valid. For example, a custom evaluator might:
  * Collect all the report files and upload them somewhere, or send them to Slack or an email address
  * Use the GitHub API to report the issues on the PR that the build is running on, à la [GNAG](https://github.com/btkelly/gnag)
- * Only break the build if there's errors or warnings in one specific report
+ * Only break the build if there are errors or warnings in one specific report
  * Or anything else that you can think of
 
 Please note that the presence of an `evaluator` property will make the plugin ignore the `penalty` closure and its thresholds. If you


### PR DESCRIPTION
This PR adds the documentation for the custom evaluators feature (see #45).