### PR TITLE
[PT-523] - Move Violations out of the internal package

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectFactory

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,7 +1,6 @@
 package com.novoda.staticanalysis
 
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
-import com.novoda.staticanalysis.internal.Violations
 import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
 import com.novoda.staticanalysis.internal.detekt.DetektConfigurator
 import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/Violations.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/Violations.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis.internal;
+package com.novoda.staticanalysis;
 
 class Violations {
     private final String toolName

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/ViolationsEvaluator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/ViolationsEvaluator.groovy
@@ -1,7 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
-
 interface ViolationsEvaluator {
 
     void evaluate(Set<Violations> allViolations)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -1,6 +1,7 @@
 package com.novoda.staticanalysis.internal
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CollectViolationsTask.groovy
@@ -1,5 +1,6 @@
 package com.novoda.staticanalysis.internal
 
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -2,7 +2,7 @@ package com.novoda.staticanalysis.internal.checkstyle
 
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.*
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -1,8 +1,8 @@
 package com.novoda.staticanalysis.internal.checkstyle
 
+import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.Violations
 import org.gradle.api.*
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CollectCheckstyleViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CollectCheckstyleViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.checkstyle
 
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CollectViolationsTask
 import groovy.util.slurpersupport.GPathResult
 
 class CollectCheckstyleViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CollectCheckstyleViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CollectCheckstyleViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.checkstyle
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import groovy.util.slurpersupport.GPathResult
 
 class CollectCheckstyleViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/CollectDetektViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/CollectDetektViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.detekt
 
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CollectViolationsTask
 import groovy.util.slurpersupport.GPathResult
 
 class CollectDetektViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/CollectDetektViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/CollectDetektViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.detekt
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import groovy.util.slurpersupport.GPathResult
 
 class CollectDetektViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -2,7 +2,7 @@ package com.novoda.staticanalysis.internal.detekt
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.internal.Configurator
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -1,8 +1,8 @@
 package com.novoda.staticanalysis.internal.detekt
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
-import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.Configurator
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/CollectFindbugsViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/CollectFindbugsViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.findbugs
 
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CollectViolationsTask
 
 class CollectFindbugsViolationsTask extends CollectViolationsTask {
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/CollectFindbugsViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/CollectFindbugsViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 
 class CollectFindbugsViolationsTask extends CollectViolationsTask {
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.findbugs
 
-import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import org.gradle.api.*
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.*
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.lint
 
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CollectViolationsTask
 import groovy.util.slurpersupport.GPathResult
 
 class CollectLintViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.lint
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import groovy.util.slurpersupport.GPathResult
 
 class CollectLintViolationsTask extends CollectViolationsTask {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -1,8 +1,8 @@
 package com.novoda.staticanalysis.internal.lint
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
-import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.Configurator
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -2,7 +2,7 @@ package com.novoda.staticanalysis.internal.lint
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.internal.Configurator
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/CollectPmdViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/CollectPmdViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.pmd
 
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.CollectViolationsTask
 
 class CollectPmdViolationsTask extends CollectViolationsTask {
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/CollectPmdViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/CollectPmdViolationsTask.groovy
@@ -1,7 +1,7 @@
 package com.novoda.staticanalysis.internal.pmd
 
 import com.novoda.staticanalysis.internal.CollectViolationsTask
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 
 class CollectPmdViolationsTask extends CollectViolationsTask {
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -1,8 +1,8 @@
 package com.novoda.staticanalysis.internal.pmd
 
+import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.Violations
 import org.gradle.api.*
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -2,7 +2,7 @@ package com.novoda.staticanalysis.internal.pmd
 
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import org.gradle.api.*
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluatorTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluatorTest.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 import org.junit.Before

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/StaticAnalysisExtensionTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/StaticAnalysisExtensionTest.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -1,6 +1,6 @@
 package com.novoda.staticanalysis.internal.lint
 
-import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.Violations
 import com.novoda.test.Fixtures
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder


### PR DESCRIPTION
[PT-523](https://novoda.atlassian.net/browse/PT-523)

### Description
With version 0.5 `Violations` are part of the public API, but they're still located in the `internal` package. Click [here](https://github.com/novoda/gradle-static-analysis-plugin/issues/67) for more details.  