### PR TITLE
PT-548: Consume gradle plugins repo credentials from secrets.properties

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -69,8 +69,6 @@ prepareGhPages.dependsOn groovydoc
 publishGhPages.dependsOn prepareGhCredentials
 
 task prepareGradlePluginsRepoRelease {
-    description = "Prepare the release to the Gradle Plugins Repository"
-    group = 'release'
     doLast {
         // force evaluation of properties to check whether they're there or not
         buildProperties.secrets['gradle.publish.key'].string

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -84,11 +84,11 @@ private static void validateSecrets(File secretsProperties) {
     def props = new Properties()
     secretsProperties.withInputStream { props.load(it) }
 
-    if (!props.hasProperty('gradle.publish.key')) {
+    if (!props.containsKey('gradle.publish.key')) {
         throw new GradleException('Could not find find gradle.publish.key in secrets.properties')
     }
 
-    if (!props.hasProperty('gradle.publish.secret')) {
+    if (!props.containsKey('gradle.publish.secret')) {
         throw new GradleException('Could not find find gradle.publish.secret in secrets.properties')
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -23,6 +23,8 @@ buildProperties {
 This file should contain:
 - git.username: the username used to push to the repo
 - git.password: the password used to push to the repo
+- gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
+- gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
 		''')
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -72,7 +72,7 @@ task prepareGradlePluginsRepoRelease {
     description = "Prepares the release to the Gradle Plugins Repository"
     group = 'release'
     doLast {
-        def secretsProperties = project.file('secrets.properties')
+        def secretsProperties = rootProject.file('secrets.properties')
         if (secretsProperties.exists()) {
             validateSecrets(secretsProperties)
             System.properties['com.gradle.login.properties.file'] = secretsProperties.absolutePath

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -119,7 +119,24 @@ task prepareGradlePluginsRepoRelease {
     description = "Prepares the release to the Gradle Plugins Repository"
     group = 'release'
     doLast {
-        println("TODO: prepare the release")
+        def secretsProperties = project.file('secrets.properties')
+        if (secretsProperties.exists()) {
+            validateSecrets(secretsProperties)
+            System.properties['com.gradle.login.properties.file'] = secretsProperties.absolutePath
+        }
+    }
+}
+
+private static void validateSecrets(File secretsProperties) {
+    def props = new Properties()
+    secretsProperties.withInputStream { props.load(it) }
+
+    if (!props.hasProperty('gradle.publish.key')) {
+        throw new GradleException('Could not find find gradle.publish.key in secrets.properties')
+    }
+
+    if (!props.hasProperty('gradle.publish.secret')) {
+        throw new GradleException('Could not find find gradle.publish.secret in secrets.properties')
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -72,24 +72,10 @@ task prepareGradlePluginsRepoRelease {
     description = "Prepare the release to the Gradle Plugins Repository"
     group = 'release'
     doLast {
-        def secretsProperties = rootProject.file('secrets.properties')
-        if (secretsProperties.exists()) {
-            validateSecrets(secretsProperties)
-            System.properties['com.gradle.login.properties.file'] = secretsProperties.absolutePath
-        }
-    }
-}
-
-private static void validateSecrets(File secretsProperties) {
-    def props = new Properties()
-    secretsProperties.withInputStream { props.load(it) }
-
-    if (!props.containsKey('gradle.publish.key')) {
-        throw new GradleException('Could not find find gradle.publish.key in secrets.properties')
-    }
-
-    if (!props.containsKey('gradle.publish.secret')) {
-        throw new GradleException('Could not find find gradle.publish.secret in secrets.properties')
+        // force evaluation of properties to check whether they're there or not
+        buildProperties.secrets['gradle.publish.key'].string
+        buildProperties.secrets['gradle.publish.secret'].string
+        System.properties['com.gradle.login.properties.file'] = rootProject.file('secrets.properties')
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -68,10 +68,35 @@ task prepareGhCredentials {
 prepareGhPages.dependsOn groovydoc
 publishGhPages.dependsOn prepareGhCredentials
 
+task prepareGradlePluginsRepoRelease {
+    description = "Prepares the release to the Gradle Plugins Repository"
+    group = 'release'
+    doLast {
+        def secretsProperties = project.file('secrets.properties')
+        if (secretsProperties.exists()) {
+            validateSecrets(secretsProperties)
+            System.properties['com.gradle.login.properties.file'] = secretsProperties.absolutePath
+        }
+    }
+}
+
+private static void validateSecrets(File secretsProperties) {
+    def props = new Properties()
+    secretsProperties.withInputStream { props.load(it) }
+
+    if (!props.hasProperty('gradle.publish.key')) {
+        throw new GradleException('Could not find find gradle.publish.key in secrets.properties')
+    }
+
+    if (!props.hasProperty('gradle.publish.secret')) {
+        throw new GradleException('Could not find find gradle.publish.secret in secrets.properties')
+    }
+}
+
 task prepareRelease {
     description = 'Prepare changelog and tag for release'
     group = 'release'
-    dependsOn prepareGhPages, prepareGhCredentials
+    dependsOn prepareGhPages, prepareGhCredentials, prepareGradlePluginsRepoRelease
     doLast {
         String changelog = extractChangelog()
         grgit.tag.add {
@@ -117,36 +142,10 @@ task publishGroovydoc {
     mustRunAfter publishArtifact
 }
 
-task prepareGradlePluginsRepoRelease {
-    description = "Prepares the release to the Gradle Plugins Repository"
-    group = 'release'
-    doLast {
-        def secretsProperties = project.file('secrets.properties')
-        if (secretsProperties.exists()) {
-            validateSecrets(secretsProperties)
-            System.properties['com.gradle.login.properties.file'] = secretsProperties.absolutePath
-        }
-    }
-}
-
-private static void validateSecrets(File secretsProperties) {
-    def props = new Properties()
-    secretsProperties.withInputStream { props.load(it) }
-
-    if (!props.hasProperty('gradle.publish.key')) {
-        throw new GradleException('Could not find find gradle.publish.key in secrets.properties')
-    }
-
-    if (!props.hasProperty('gradle.publish.secret')) {
-        throw new GradleException('Could not find find gradle.publish.secret in secrets.properties')
-    }
-}
-
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
     if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
-        publishPlugins.dependsOn prepareGradlePluginsRepoRelease
         dependsOn prepareRelease, publishArtifact, publishGroovydoc, publishPlugins
         doLast {
             grgit.push {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -115,10 +115,19 @@ task publishGroovydoc {
     mustRunAfter publishArtifact
 }
 
+task prepareGradlePluginsRepoRelease {
+    description = "Prepares the release to the Gradle Plugins Repository"
+    group = 'release'
+    doLast {
+        println("TODO: prepare the release")
+    }
+}
+
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
     if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
+        publishPlugins.dependsOn prepareGradlePluginsRepoRelease
         dependsOn prepareRelease, publishArtifact, publishGroovydoc, publishPlugins
         doLast {
             grgit.push {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -69,7 +69,7 @@ prepareGhPages.dependsOn groovydoc
 publishGhPages.dependsOn prepareGhCredentials
 
 task prepareGradlePluginsRepoRelease {
-    description = "Prepares the release to the Gradle Plugins Repository"
+    description = "Prepare the release to the Gradle Plugins Repository"
     group = 'release'
     doLast {
         def secretsProperties = rootProject.file('secrets.properties')


### PR DESCRIPTION
### Description 
According to the [documentation](https://plugins.gradle.org/docs/submit) the credentials for the gradle plugins repository need to be put to the `gradle.properties`. But this would mean we'd depend on a specific machine.

I checked the [source code](https://plugins.gradle.org/m2/com/gradle/publish/plugin-publish-plugin/0.9.1/?_ga=2.243434636.886326088.1517819728-636804111.1514966621) of the plugin (the last version which is available as open source) and found out that we can overwrite this by setting a system property `com.gradle.login.properties.file` and link to another file instead.

Since we're using the `build-properties` plugin we decided to use the `secrets.properties`. The goal of this PR is to set `com.gradle.login.properties.file` to the path of `secrets.properties` if it is available and contains the needed credentials.

### Considerations
- If `secrets.properties` exists and it contains `gradle.publish.key`, `gradle.publish.secret` set `com.gradle.login.properties.file` to it's absolute path
