### PR TITLE
[PT-563] Consume gradle plugins repo credentials from env

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -70,8 +70,10 @@ publishGhPages.dependsOn prepareGhCredentials
 
 task prepareGradlePluginsRepoRelease {
     doLast {
-        project.setProperty('gradle.publish.key', buildProperties.env['GRADLE_PLUGINS_REPO_KEY'])
-        project.setProperty('gradle.publish.secret', buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'])
+        String key = buildProperties.env['GRADLE_PLUGINS_REPO_KEY'].or(buildProperties.secrets['gradle.publish.key']).string
+        String secret = buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'].or(buildProperties.secrets['gradle.publish.secret']).string
+        project.setProperty('gradle.publish.key', key)
+        project.setProperty('gradle.publish.secret', secret)
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -70,10 +70,8 @@ publishGhPages.dependsOn prepareGhCredentials
 
 task prepareGradlePluginsRepoRelease {
     doLast {
-        // force evaluation of properties to check whether they're there or not
-        buildProperties.secrets['gradle.publish.key'].string
-        buildProperties.secrets['gradle.publish.secret'].string
-        System.properties['com.gradle.login.properties.file'] = rootProject.file('secrets.properties')
+        project.setProperty('gradle.publish.key', buildProperties.env['GRADLE_PLUGINS_REPO_KEY'])
+        project.setProperty('gradle.publish.secret', buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'])
     }
 }
 


### PR DESCRIPTION
Tracked in JIRA [PT-563](https://novoda.atlassian.net/browse/PT-563)

### Description
By having another look at the [documentation](https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/) I read that there is an alternative to putting the credentials to the `gradle.properties`. Instead we can set these project properties `-Pgradle.publish.key=<key> -Pgradle.publish.secret=<secret>`.

I added the credentials to Jenkins through the credentials plugin and bind them to the env variables `GRADLE_PLUGINS_REPO_KEY` and `GRADLE_PLUGINS_REPO_SECRET`.

Scope of this PR is to change `prepareGradlePluginsRepoRelease` to read these credentials from the env variables and set the project properties. As fallback for a local release we still also check the `secrets.properties`.

