### PR TITLE
Android lint variant filter support

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -15,8 +15,8 @@ class StaticAnalysisPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        StaticAnalysisExtension pluginExtension = project.extensions.create('staticAnalysis', StaticAnalysisExtension, project)
-        Task evaluateViolations = createEvaluateViolationsTask(project, pluginExtension)
+        def pluginExtension = project.extensions.create('staticAnalysis', StaticAnalysisExtension, project)
+        def evaluateViolations = createEvaluateViolationsTask(project, pluginExtension)
         createConfigurators(project, pluginExtension, evaluateViolations).each { configurator -> configurator.execute() }
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -36,13 +36,13 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
             }
             project.plugins.withId('com.android.application') {
                 project.afterEvaluate {
-                    configureAndroidProject(filteredApplicationVariants)
+                    configureAndroidProject(filteredApplicationAndTestVariants)
                     configureToolTasks()
                 }
             }
             project.plugins.withId('com.android.library') {
                 project.afterEvaluate {
-                    configureAndroidProject(filteredLibraryVariants)
+                    configureAndroidProject(filteredLibraryAndTestVariants)
                     configureToolTasks()
                 }
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -15,7 +15,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     protected final Violations violations
     protected final Task evaluateViolations
     protected final SourceFilter sourceFilter
-    private final VariantFilter variantFilter
+    protected final VariantFilter variantFilter
 
     protected CodeQualityConfigurator(Project project, Violations violations, Task evaluateViolations) {
         this.project = project

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -9,20 +9,18 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.tasks.SourceTask
 
-abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQualityExtension> implements Configurator {
+abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQualityExtension> implements Configurator, VariantAware {
 
     protected final Project project
     protected final Violations violations
     protected final Task evaluateViolations
     protected final SourceFilter sourceFilter
-    protected Closure<Boolean> includeVariantsFilter
 
     protected CodeQualityConfigurator(Project project, Violations violations, Task evaluateViolations) {
         this.project = project
         this.violations = violations
         this.evaluateViolations = evaluateViolations
         this.sourceFilter = new SourceFilter(project)
-        this.includeVariantsFilter = { true }
     }
 
     @Override
@@ -38,13 +36,13 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
             }
             project.plugins.withId('com.android.application') {
                 project.afterEvaluate {
-                    configureAndroidProject(allApplicationVariants.matching { includeVariantsFilter(it) })
+                    configureAndroidProject(filteredApplicationVariants)
                     configureToolTasks()
                 }
             }
             project.plugins.withId('com.android.library') {
                 project.afterEvaluate {
-                    configureAndroidProject(allLibraryVariants.matching { includeVariantsFilter(it) })
+                    configureAndroidProject(filteredLibraryVariants)
                     configureToolTasks()
                 }
             }
@@ -57,27 +55,11 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
         }
     }
 
-    protected NamedDomainObjectSet<Object> getAllApplicationVariants() {
-        getAllVariants(project.android.applicationVariants)
-    }
-
     protected void configureToolTasks() {
         project.tasks.withType(taskClass) { task ->
             task.group = 'verification'
             configureReportEvaluation(task, violations)
         }
-    }
-
-    protected NamedDomainObjectSet<Object> getAllLibraryVariants() {
-        getAllVariants(project.android.libraryVariants)
-    }
-
-    private NamedDomainObjectSet<Object> getAllVariants(variants1) {
-        NamedDomainObjectSet<Object> variants = project.container(Object)
-        variants.addAll(variants1)
-        variants.addAll(project.android.testVariants)
-        variants.addAll(project.android.unitTestVariants)
-        return variants
     }
 
     protected abstract String getToolName()

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
@@ -5,32 +5,26 @@ import org.gradle.api.NamedDomainObjectSet
 
 trait VariantAware {
 
-    private boolean hasFilter = false
-    Closure<Boolean> includeVariantsFilter = { true }
+    Closure<Boolean> includeVariantsFilter
 
-    void setIncludeVariantsFilter(Closure<Boolean> includeVariantsFilter) {
-        this.hasFilter = true
-        this.includeVariantsFilter = includeVariantsFilter
-    }
-
-    boolean getHasFilter() {
-        hasFilter
+    final variantSelector = { DomainObjectSet variants ->
+        includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
     }
 
     DomainObjectSet<Object> getFilteredApplicationVariants() {
-        project.android.applicationVariants.matching { includeVariantsFilter(it) }
+        variantSelector(project.android.applicationVariants)
     }
 
     NamedDomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
-        getAllVariants(project.android.applicationVariants).matching { includeVariantsFilter(it) }
+        variantSelector(getAllVariants(project.android.applicationVariants))
     }
 
     DomainObjectSet<Object> getFilteredLibraryVariants() {
-        project.android.libraryVariants.matching { includeVariantsFilter(it) }
+        variantSelector(project.android.libraryVariants)
     }
 
     NamedDomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
-        getAllVariants(project.android.libraryVariants).matching { includeVariantsFilter(it) }
+        variantSelector(getAllVariants(project.android.libraryVariants))
     }
 
     private NamedDomainObjectSet<Object> getAllVariants(variants1) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
@@ -1,0 +1,24 @@
+package com.novoda.staticanalysis.internal
+
+import org.gradle.api.NamedDomainObjectSet
+
+trait VariantAware {
+
+    Closure<Boolean> includeVariantsFilter = { true }
+
+    NamedDomainObjectSet<Object> getFilteredApplicationVariants() {
+        getAllVariants(project.android.applicationVariants).matching { includeVariantsFilter(it) }
+    }
+
+    NamedDomainObjectSet<Object> getFilteredLibraryVariants() {
+        getAllVariants(project.android.libraryVariants).matching { includeVariantsFilter(it) }
+    }
+
+    private NamedDomainObjectSet<Object> getAllVariants(variants1) {
+        NamedDomainObjectSet<Object> variants = project.container(Object)
+        variants.addAll(variants1)
+        variants.addAll(project.android.testVariants)
+        variants.addAll(project.android.unitTestVariants)
+        return variants
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
@@ -1,16 +1,25 @@
 package com.novoda.staticanalysis.internal
 
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectSet
 
 trait VariantAware {
 
     Closure<Boolean> includeVariantsFilter = { true }
 
-    NamedDomainObjectSet<Object> getFilteredApplicationVariants() {
+    DomainObjectSet<Object> getFilteredApplicationVariants() {
+        project.android.applicationVariants.matching { includeVariantsFilter(it) }
+    }
+
+    DomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
         getAllVariants(project.android.applicationVariants).matching { includeVariantsFilter(it) }
     }
 
-    NamedDomainObjectSet<Object> getFilteredLibraryVariants() {
+    DomainObjectSet<Object> getFilteredLibraryVariants() {
+        project.android.libraryVariants.matching { includeVariantsFilter(it) }
+    }
+
+    DomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
         getAllVariants(project.android.libraryVariants).matching { includeVariantsFilter(it) }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
@@ -7,7 +7,7 @@ trait VariantAware {
 
     Closure<Boolean> includeVariantsFilter
 
-    final variantSelector = { DomainObjectSet variants ->
+    final variantSelector = { variants ->
         includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantAware.groovy
@@ -5,13 +5,23 @@ import org.gradle.api.NamedDomainObjectSet
 
 trait VariantAware {
 
+    private boolean hasFilter = false
     Closure<Boolean> includeVariantsFilter = { true }
+
+    void setIncludeVariantsFilter(Closure<Boolean> includeVariantsFilter) {
+        this.hasFilter = true
+        this.includeVariantsFilter = includeVariantsFilter
+    }
+
+    boolean getHasFilter() {
+        hasFilter
+    }
 
     DomainObjectSet<Object> getFilteredApplicationVariants() {
         project.android.applicationVariants.matching { includeVariantsFilter(it) }
     }
 
-    DomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
+    NamedDomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
         getAllVariants(project.android.applicationVariants).matching { includeVariantsFilter(it) }
     }
 
@@ -19,7 +29,7 @@ trait VariantAware {
         project.android.libraryVariants.matching { includeVariantsFilter(it) }
     }
 
-    DomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
+    NamedDomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
         getAllVariants(project.android.libraryVariants).matching { includeVariantsFilter(it) }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantFilter.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantFilter.groovy
@@ -2,29 +2,35 @@ package com.novoda.staticanalysis.internal
 
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectSet
+import org.gradle.api.Project
 
-trait VariantAware {
+final class VariantFilter {
 
+    private final Project project
     Closure<Boolean> includeVariantsFilter
 
-    final variantSelector = { variants ->
-        includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
+    VariantFilter(Project project) {
+        this.project = project
     }
 
     DomainObjectSet<Object> getFilteredApplicationVariants() {
-        variantSelector(project.android.applicationVariants)
+        filterVariants(project.android.applicationVariants)
     }
 
     NamedDomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
-        variantSelector(getAllVariants(project.android.applicationVariants))
+        filterVariants(getAllVariants(project.android.applicationVariants))
     }
 
     DomainObjectSet<Object> getFilteredLibraryVariants() {
-        variantSelector(project.android.libraryVariants)
+        filterVariants(project.android.libraryVariants)
     }
 
     NamedDomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
-        variantSelector(getAllVariants(project.android.libraryVariants))
+        filterVariants(getAllVariants(project.android.libraryVariants))
+    }
+    
+    private def filterVariants(variants) {
+        includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
     }
 
     private NamedDomainObjectSet<Object> getAllVariants(variants1) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -4,7 +4,6 @@ import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.internal.VariantAware
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -32,23 +31,24 @@ class LintConfigurator implements Configurator, VariantAware {
     void execute() {
         project.extensions.findByType(StaticAnalysisExtension).ext.lintOptions = { Closure config ->
             project.plugins.withId('com.android.application') {
-                configureWithVariants(config, filteredApplicationVariants)
+                configureLint(config)
+                if (includeVariantsFilter != null) {
+                    filteredApplicationVariants.all { configureCollectViolationsTask(it) }
+                } else {
+                    configureCollectViolationsTask()
+                }
             }
             project.plugins.withId('com.android.library') {
-                configureWithVariants(config, filteredLibraryVariants)
+                configureLint(config)
+                if (includeVariantsFilter != null) {
+                    filteredLibraryVariants.all { configureCollectViolationsTask(it) }
+                } else {
+                    configureCollectViolationsTask()
+                }
             }
-
         }
     }
 
-    private void configureWithVariants(Closure config, DomainObjectSet variants) {
-        configureLint(config)
-        if (includeVariantsFilter != null) {
-            variants.all { configureCollectViolationsTask(it) }
-        } else {
-            configureCollectViolationsTask()
-        }
-    }
 
     private void configureLint(Closure config) {
         project.android.lintOptions.ext.includeVariants = { Closure<Boolean> filter ->

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -43,7 +43,7 @@ class LintConfigurator implements Configurator, VariantAware {
 
     private void configureWithVariants(Closure config, DomainObjectSet variants) {
         configureLint(config)
-        if (hasFilter) {
+        if (includeVariantsFilter != null) {
             variants.all { configureCollectViolationsTask(it) }
         } else {
             configureCollectViolationsTask()

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -4,6 +4,7 @@ import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.internal.VariantFilter
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -34,27 +35,14 @@ class LintConfigurator implements Configurator {
         project.extensions.findByType(StaticAnalysisExtension).ext.lintOptions = { Closure config ->
             project.plugins.withId('com.android.application') {
                 configureLint(config)
-                if (variantFilter.includeVariantsFilter != null) {
-                    variantFilter.filteredApplicationVariants.all {
-                        configureCollectViolationsTask(it.name, "lint-results-${it.name}")
-                    }
-                } else {
-                    configureCollectViolationsTask('lint-results')
-                }
+                configureWithVariants(variantFilter.filteredApplicationVariants)
             }
             project.plugins.withId('com.android.library') {
                 configureLint(config)
-                if (variantFilter.includeVariantsFilter != null) {
-                    variantFilter.filteredLibraryVariants.all {
-                        configureCollectViolationsTask(it.name, "lint-results-${it.name}")
-                    }
-                } else {
-                    configureCollectViolationsTask('lint-results')
-                }
+                configureWithVariants(variantFilter.filteredLibraryVariants)
             }
         }
     }
-
 
     private void configureLint(Closure config) {
         project.android.lintOptions.ext.includeVariants = { Closure<Boolean> filter ->
@@ -65,6 +53,16 @@ class LintConfigurator implements Configurator {
             xmlReport = true
             htmlReport = true
             abortOnError false
+        }
+    }
+
+    private void configureWithVariants(DomainObjectSet variants) {
+        if (variantFilter.includeVariantsFilter != null) {
+            variants.all {
+                configureCollectViolationsTask(it.name, "lint-results-${it.name}")
+            }
+        } else {
+            configureCollectViolationsTask('lint-results')
         }
     }
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -11,7 +11,7 @@ import static com.google.common.truth.Truth.assertThat
 class CollectLintViolationsTaskTest {
 
     @Test
-    void shouldAddResultsToViolations() throws Exception {
+    void shouldAddResultsToViolations() {
         Project project = ProjectBuilder.builder().build()
         def task = project.task('collectLintViolationsTask', type: CollectLintViolationsTask)
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintAndroidVariantIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintAndroidVariantIntegrationTest.groovy
@@ -1,0 +1,117 @@
+package com.novoda.staticanalysis.internal.lint
+
+import com.google.common.truth.Truth
+import com.novoda.test.Fixtures
+import com.novoda.test.TestAndroidProject
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+import static com.novoda.test.LogsSubject.assertThat
+
+class LintAndroidVariantIntegrationTest {
+
+    private static String LINT_CONFIGURATION =
+            """
+        lintOptions {              
+            lintConfig = file("${Fixtures.Lint.RULES}") 
+        }
+        """
+
+    @Rule
+    public
+    final TestProjectRule<TestAndroidProject> projectRule = TestProjectRule.forAndroidProject()
+
+    @Test
+    void shouldFailBuildWhenLintViolationsOverThresholdInActiveProductFlavorVariant() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Lint.SOURCES_WITH_WARNINGS)
+                .withSourceSet('demo', Fixtures.Lint.SOURCES_WITH_ERRORS)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''    
+                    flavorDimensions 'tier'
+                    productFlavors {
+                        demo { dimension 'tier' }
+                        full { dimension 'tier' }
+                    }
+                ''')
+                .withToolsConfig(LINT_CONFIGURATION)
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(2, 3)
+        assertThat(result.logs).containsLintViolations(2, 4,
+                'reports/lint-results-demoDebug.html')
+    }
+
+    @Test
+    void shouldContainCollectLintTasksForAllVariantsByDefault() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 1
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    flavorDimensions 'tier'
+
+                    productFlavors {
+                        demo { dimension 'tier' }
+                        full { dimension 'tier' }
+                    }
+                ''')
+                .withToolsConfig(LINT_CONFIGURATION)
+                .build('check')
+
+        Truth.assertThat(result.tasksPaths).containsAllOf(
+                ":lintDemoDebug",
+                ":collectLintDemoDebugViolations",
+                ":lintDemoRelease",
+                ":collectLintDemoReleaseViolations",
+                ":lintFullDebug",
+                ":collectLintFullDebugViolations",
+                ":lintFullRelease",
+                ":collectLintFullReleaseViolations"
+        )
+    }
+
+    @Test
+    void shouldContainCollectLintTasksForIncludedVariantsOnly() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxErrors = 1
+                    maxWarnings = 1
+                }''')
+                .withAdditionalAndroidConfig('''
+                    flavorDimensions 'tier'
+
+                    productFlavors {
+                        demo { dimension 'tier' }
+                        full { dimension 'tier' }
+                    }
+                ''')
+                .withToolsConfig("""
+                    lintOptions {              
+                        lintConfig = file("${Fixtures.Lint.RULES}")               
+                        includeVariants { it.name == 'demoDebug' }
+                    }
+                """)
+                .build('check')
+
+        Truth.assertThat(result.tasksPaths).containsAllOf(
+                ":lintDemoDebug",
+                ":collectLintDemoDebugViolations")
+        Truth.assertThat(result.tasksPaths).containsNoneOf(
+                ":lintDemoRelease",
+                ":collectLintDemoReleaseViolations",
+                ":lintFullDebug",
+                ":collectLintFullDebugViolations",
+                ":lintFullRelease",
+                ":collectLintFullReleaseViolations")
+    }
+
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -17,7 +17,7 @@ class LintIntegrationTest {
         """
 
     @Test
-    void shouldFailBuildWhenLintErrorsOverTheThresholds() throws Exception {
+    void shouldFailBuildWhenLintErrorsOverTheThresholds() {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 0)
                 .buildAndFail('check')
 
@@ -25,7 +25,7 @@ class LintIntegrationTest {
     }
 
     @Test
-    void shouldNotFailBuildWhenLintErrorsWithinTheThresholds() throws Exception {
+    void shouldNotFailBuildWhenLintErrorsWithinTheThresholds() {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_ERRORS, 0, 1)
                 .build('check')
 
@@ -33,7 +33,7 @@ class LintIntegrationTest {
     }
 
     @Test
-    void shouldFailBuildWhenLintWarningsOverTheThresholds() throws Exception {
+    void shouldFailBuildWhenLintWarningsOverTheThresholds() {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 0, 0)
                 .buildAndFail('check')
 
@@ -41,7 +41,7 @@ class LintIntegrationTest {
     }
 
     @Test
-    void shouldNotFailBuildWhenLintWarningsWithinTheThresholds() throws Exception {
+    void shouldNotFailBuildWhenLintWarningsWithinTheThresholds() {
         def result = createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 1, 0)
                 .build('check')
 


### PR DESCRIPTION
Fixes #66 
Fixes #77 

## Problem 

The lint setup didn't have filters around Android variants. In a big project with 10+ variants, the `evaluateViolations` task take too long. (around 20 mins)

## Solution

This PR make `lintOptions` variant aware. 

- Introduced a `trait` to encapsulate Android variant awareness in Configurators.
  - A follow-up will be done to this to make it cleaner.
- Instead of skipping non-android projects, use `project.plugins.withId('com.android.application')` to wait for potential plugin addition. This will fix the timing issue described in #77 
- When lint runs on a single variant, the output names change. That's why introduced `Nullable` variant param to task creation and change the report file path accordingly. 

**Note:** When filter is not provided, it will keep the old behavior. When filter is used, we may get duplicated results when the same problem is available in an intersection of the sourceSets of multiple variants. This problem is available in all tasks and fix will be introduced later. 

## Tests

Lots of tests added including the duplicate number behavior.
A test is also added to check if we really ignore problems when the variant is ignored.