### PR TITLE
Clean up variant aware code

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -3,6 +3,7 @@ package com.novoda.staticanalysis.internal
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.Violations
 import org.gradle.api.Action
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.quality.CodeQualityExtension
@@ -36,22 +37,22 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 config()
             }
             project.plugins.withId('com.android.application') {
-                variantFilter.filteredApplicationVariants.all { configureAndroidVariant(it) }
-                variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
-                variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
+                configureAndroidWithVariants(filteredApplicationVariants)
             }
             project.plugins.withId('com.android.library') {
-                variantFilter.filteredLibraryVariants.all { configureAndroidVariant(it) }
-                variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
-                variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
+                configureAndroidWithVariants(filteredLibraryVariants)
             }
             project.plugins.withId('java') {
-                project.afterEvaluate {
-                    configureJavaProject()
-                }
+                configureJavaProject()
             }
             configureToolTasks()
         }
+    }
+
+    private void configureAndroidWithVariants(DomainObjectSet variants) {
+        variantFilter.variants.all { configureAndroidVariant(it) }
+        variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
+        variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
     }
 
     protected void configureToolTasks() {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -38,24 +38,26 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
             }
             project.plugins.withId('com.android.application') {
                 configureAndroidWithVariants(filteredApplicationVariants)
+                configureToolTasks()
             }
             project.plugins.withId('com.android.library') {
                 configureAndroidWithVariants(filteredLibraryVariants)
+                configureToolTasks()
             }
             project.plugins.withId('java') {
                 configureJavaProject()
+                configureToolTasks()
             }
-            configureToolTasks()
         }
     }
 
-    private void configureAndroidWithVariants(DomainObjectSet variants) {
+    def configureAndroidWithVariants(DomainObjectSet variants) {
         variantFilter.variants.all { configureAndroidVariant(it) }
         variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
         variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
     }
 
-    protected void configureToolTasks() {
+    def configureToolTasks() {
         project.tasks.withType(taskClass) { task ->
             task.group = 'verification'
             configureReportEvaluation(task, violations)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -37,11 +37,11 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 config()
             }
             project.plugins.withId('com.android.application') {
-                configureAndroidWithVariants(filteredApplicationVariants)
+                configureAndroidWithVariants(variantFilter.filteredApplicationVariants)
                 configureToolTasks()
             }
             project.plugins.withId('com.android.library') {
-                configureAndroidWithVariants(filteredLibraryVariants)
+                configureAndroidWithVariants(variantFilter.filteredLibraryVariants)
                 configureToolTasks()
             }
             project.plugins.withId('java') {
@@ -52,7 +52,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     }
 
     def configureAndroidWithVariants(DomainObjectSet variants) {
-        variantFilter.variants.all { configureAndroidVariant(it) }
+        variants.all { configureAndroidVariant(it) }
         variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
         variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -3,7 +3,6 @@ package com.novoda.staticanalysis.internal
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.Violations
 import org.gradle.api.Action
-import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.quality.CodeQualityExtension
@@ -37,23 +36,21 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 config()
             }
             project.plugins.withId('com.android.application') {
-                project.afterEvaluate {
-                    configureAndroidProject(variantFilter.filteredApplicationAndTestVariants)
-                    configureToolTasks()
-                }
+                variantFilter.filteredApplicationVariants.all { configureAndroidVariant(it) }
+                variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
+                variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
             }
             project.plugins.withId('com.android.library') {
-                project.afterEvaluate {
-                    configureAndroidProject(variantFilter.filteredLibraryAndTestVariants)
-                    configureToolTasks()
-                }
+                variantFilter.filteredLibraryVariants.all { configureAndroidVariant(it) }
+                variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
+                variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
             }
             project.plugins.withId('java') {
                 project.afterEvaluate {
                     configureJavaProject()
-                    configureToolTasks()
                 }
             }
+            configureToolTasks()
         }
     }
 
@@ -80,7 +77,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
         }
     }
 
-    protected abstract void configureAndroidProject(NamedDomainObjectSet variants)
+    protected abstract void configureAndroidVariant(variant)
 
     protected void configureJavaProject() {
         project.tasks.withType(taskClass) { task -> sourceFilter.applyTo(task) }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantFilter.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/VariantFilter.groovy
@@ -1,7 +1,6 @@
 package com.novoda.staticanalysis.internal
 
 import org.gradle.api.DomainObjectSet
-import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 
 final class VariantFilter {
@@ -13,31 +12,23 @@ final class VariantFilter {
         this.project = project
     }
 
-    DomainObjectSet<Object> getFilteredApplicationVariants() {
+    DomainObjectSet getFilteredApplicationVariants() {
         filterVariants(project.android.applicationVariants)
     }
 
-    NamedDomainObjectSet<Object> getFilteredApplicationAndTestVariants() {
-        filterVariants(getAllVariants(project.android.applicationVariants))
-    }
-
-    DomainObjectSet<Object> getFilteredLibraryVariants() {
+    DomainObjectSet getFilteredLibraryVariants() {
         filterVariants(project.android.libraryVariants)
     }
 
-    NamedDomainObjectSet<Object> getFilteredLibraryAndTestVariants() {
-        filterVariants(getAllVariants(project.android.libraryVariants))
-    }
-    
-    private def filterVariants(variants) {
-        includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
+    DomainObjectSet getFilteredTestVariants() {
+        filterVariants(project.android.testVariants)
     }
 
-    private NamedDomainObjectSet<Object> getAllVariants(variants1) {
-        NamedDomainObjectSet<Object> variants = project.container(Object)
-        variants.addAll(variants1)
-        variants.addAll(project.android.testVariants)
-        variants.addAll(project.android.unitTestVariants)
-        return variants
+    DomainObjectSet getFilteredUnitTestVariants() {
+        filterVariants(project.android.unitTestVariants)
+    }
+
+    private DomainObjectSet filterVariants(DomainObjectSet variants) {
+        includeVariantsFilter != null ? variants.matching { includeVariantsFilter(it) } : variants
     }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -48,23 +48,21 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     }
 
     @Override
-    protected void configureAndroidProject(NamedDomainObjectSet variants) {
+    protected void configureAndroidVariant(variant) {
         project.with {
-            variants.all { variant ->
-                variant.sourceSets.each { sourceSet ->
-                    def taskName = "checkstyle${sourceSet.name.capitalize()}"
-                    Checkstyle task = tasks.findByName(taskName)
-                    if (task == null) {
-                        task = tasks.create(taskName, Checkstyle)
-                        task.with {
-                            description = "Run Checkstyle analysis for ${sourceSet.name} classes"
-                            source = sourceSet.java.srcDirs
-                            classpath = files("$buildDir/intermediates/classes/")
-                        }
+            variant.sourceSets.each { sourceSet ->
+                def taskName = "checkstyle${sourceSet.name.capitalize()}"
+                Checkstyle task = tasks.findByName(taskName)
+                if (task == null) {
+                    task = tasks.create(taskName, Checkstyle)
+                    task.with {
+                        description = "Run Checkstyle analysis for ${sourceSet.name} classes"
+                        source = sourceSet.java.srcDirs
+                        classpath = files("$buildDir/intermediates/classes/")
                     }
-                    sourceFilter.applyTo(task)
-                    task.mustRunAfter variant.javaCompile
                 }
+                sourceFilter.applyTo(task)
+                task.mustRunAfter variant.javaCompile
             }
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -57,22 +57,20 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     @Override
-    protected void configureAndroidProject(NamedDomainObjectSet variants) {
-        variants.all { variant ->
-            FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
-            List<File> androidSourceDirs = variant.sourceSets.collect { it.javaDirectories }.flatten()
-            task.with {
-                description = "Run FindBugs analysis for ${variant.name} classes"
-                source = androidSourceDirs
-                classpath = variant.javaCompile.classpath
-            }
-            sourceFilter.applyTo(task)
-            task.conventionMapping.map("classes", {
-                List<String> includes = createIncludePatterns(task.source, androidSourceDirs)
-                getAndroidClasses(variant, includes)
-            });
-            task.dependsOn variant.javaCompile
+    protected void configureAndroidVariant(variant) {
+        FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
+        List<File> androidSourceDirs = variant.sourceSets.collect { it.javaDirectories }.flatten()
+        task.with {
+            description = "Run FindBugs analysis for ${variant.name} classes"
+            source = androidSourceDirs
+            classpath = variant.javaCompile.classpath
         }
+        sourceFilter.applyTo(task)
+        task.conventionMapping.map("classes", {
+            List<String> includes = createIncludePatterns(task.source, androidSourceDirs)
+            getAndroidClasses(variant, includes)
+        })
+        task.dependsOn variant.javaCompile
     }
 
     private FileCollection getAndroidClasses(Object variant, List<String> includes) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -79,16 +79,18 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     @Override
     protected void configureJavaProject() {
-        project.sourceSets.each { SourceSet sourceSet ->
-            String taskName = sourceSet.getTaskName(toolName, null)
-            FindBugs task = project.tasks.findByName(taskName)
-            if (task != null) {
-                sourceFilter.applyTo(task)
-                task.conventionMapping.map("classes", {
-                    List<File> sourceDirs = sourceSet.allJava.srcDirs.findAll { it.exists() }.toList()
-                    List<String> includes = createIncludePatterns(task.source, sourceDirs)
-                    getJavaClasses(sourceSet, includes)
-                });
+        project.afterEvaluate {
+            project.sourceSets.each { SourceSet sourceSet ->
+                String taskName = sourceSet.getTaskName(toolName, null)
+                FindBugs task = project.tasks.findByName(taskName)
+                if (task != null) {
+                    sourceFilter.applyTo(task)
+                    task.conventionMapping.map("classes", {
+                        List<File> sourceDirs = sourceSet.allJava.srcDirs.findAll { it.exists() }.toList()
+                        List<String> includes = createIncludePatterns(task.source, sourceDirs)
+                        getJavaClasses(sourceSet, includes)
+                    })
+                }
             }
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -3,7 +3,10 @@ package com.novoda.staticanalysis.internal.pmd
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
 
@@ -49,22 +52,20 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     }
 
     @Override
-    protected void configureAndroidProject(NamedDomainObjectSet variants) {
+    protected void configureAndroidVariant(variant) {
         project.with {
-            variants.all { variant ->
-                variant.sourceSets.each { sourceSet ->
-                    def taskName = "pmd${sourceSet.name.capitalize()}"
-                    Pmd task = tasks.findByName(taskName)
-                    if (task == null) {
-                        task = tasks.create(taskName, Pmd)
-                        task.with {
-                            description = "Run PMD analysis for ${sourceSet.name} classes"
-                            source = sourceSet.java.srcDirs
-                        }
+            variant.sourceSets.each { sourceSet ->
+                def taskName = "pmd${sourceSet.name.capitalize()}"
+                Pmd task = tasks.findByName(taskName)
+                if (task == null) {
+                    task = tasks.create(taskName, Pmd)
+                    task.with {
+                        description = "Run PMD analysis for ${sourceSet.name} classes"
+                        source = sourceSet.java.srcDirs
                     }
-                    sourceFilter.applyTo(task)
-                    task.mustRunAfter variant.javaCompile
                 }
+                sourceFilter.applyTo(task)
+                task.mustRunAfter variant.javaCompile
             }
         }
     }


### PR DESCRIPTION
⚠️ Depends in #79 

`DomainObjectSet.all` loop is live and thanks to that usually `afterEvaluate` is not necessary because the closure will be called later (just after) the variants have been added. 

`getAllVariants` was merging android variants with test and unitTest variants. This was breaking the liveliness of the set. That's why we needed `afterEvaluate`.

Since the variant aware code is extracted away, this PR cleans this up by calling `all` on variants one by one instead of merging them. 

And thanks to that, the for looping over variants happen in the base class. This means that the implementations for Checkstyle, Findbugs and PMD are cleaner because they configure 1 variant at a time.