### PR TITLE
Fix properties in release script

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -72,8 +72,8 @@ task prepareGradlePluginsRepoRelease {
     doLast {
         String key = buildProperties.env['GRADLE_PLUGINS_REPO_KEY'].or(buildProperties.secrets['gradle.publish.key']).string
         String secret = buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'].or(buildProperties.secrets['gradle.publish.secret']).string
-        project.setProperty('gradle.publish.key', key)
-        project.setProperty('gradle.publish.secret', secret)
+        project.properties['gradle.publish.key'] = key
+        project.properties['gradle.publish.secret'] = secret
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -70,10 +70,10 @@ publishGhPages.dependsOn prepareGhCredentials
 
 task prepareGradlePluginsRepoRelease {
     doLast {
-        String key = buildProperties.env['GRADLE_PLUGINS_REPO_KEY'].or(buildProperties.secrets['gradle.publish.key']).string
-        String secret = buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'].or(buildProperties.secrets['gradle.publish.secret']).string
-        project.properties['gradle.publish.key'] = key
-        project.properties['gradle.publish.secret'] = secret
+        def key = buildProperties.env['GRADLE_PLUGINS_REPO_KEY'] | buildProperties.secrets['gradle.publish.key']
+        def secret = buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'] | buildProperties.secrets['gradle.publish.secret']
+        project.properties['gradle.publish.key'] = key.string
+        project.properties['gradle.publish.secret'] = secret.string
     }
 }
 


### PR DESCRIPTION
The release script failed with `MissingPropertyException` while trying to set the property. 

It seems that `setProperty` is meant to be used when the property is already available. If not, it throws an exception. The following map interface through `properties` map seems to be the way to do it. 

While doing so, I also used or operator instead of the or method. Since it has less parenthesis, I think it is easier to see what's going on. I can revert that if wanted. 