### PR TITLE
[SAP] Set gradle plugins repo as System.properties

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -72,8 +72,8 @@ task prepareGradlePluginsRepoRelease {
     doLast {
         def key = buildProperties.env['GRADLE_PLUGINS_REPO_KEY'] | buildProperties.secrets['gradle.publish.key']
         def secret = buildProperties.env['GRADLE_PLUGINS_REPO_SECRET'] | buildProperties.secrets['gradle.publish.secret']
-        project.properties['gradle.publish.key'] = key.string
-        project.properties['gradle.publish.secret'] = secret.string
+        System.properties['gradle.publish.key'] = key.string
+        System.properties['gradle.publish.secret'] = secret.string
     }
 }
 


### PR DESCRIPTION
Tracked in [JIRA](https://novoda.atlassian.net/browse/PT-591) 

### Description
The automated release to the gradle plugins repo failed since the publish plugin could not find the credentials. 

The error message states we should set them as `System.properties`:
`Missing publishing keys. Please set gradle.publish.key and gradle.publish.secret system properties or login using the login task.`

### Considerations
Set them as `System.properties` instead.

### Test
- tested it manually