### PR TITLE
Support multiple usage of lintOptions

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -74,11 +74,11 @@ class LintConfigurator implements Configurator {
     }
 
     private CollectLintViolationsTask createCollectViolationsTask(String taskSuffix, String reportFileName, Violations violations) {
-        project.tasks.create("collectLint${taskSuffix.capitalize()}Violations", CollectLintViolationsTask) { task ->
-            task.xmlReportFile = xmlOutputFileFor(reportFileName)
-            task.htmlReportFile = htmlOutputFileFor(reportFileName)
-            task.violations = violations
-        }
+        def task = project.tasks.maybeCreate("collectLint${taskSuffix.capitalize()}Violations", CollectLintViolationsTask)
+        task.xmlReportFile = xmlOutputFileFor(reportFileName)
+        task.htmlReportFile = htmlOutputFileFor(reportFileName)
+        task.violations = violations
+        return task
     }
 
     private File xmlOutputFileFor(reportFileName) {

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/LintIntegrationTest.groovy
@@ -9,7 +9,7 @@ import static com.novoda.test.LogsSubject.assertThat
 
 class LintIntegrationTest {
 
-    private static GString LINT_CONFIGURATION =
+    private static final String LINT_CONFIGURATION =
             """
         lintOptions {              
             lintConfig = file("${Fixtures.Lint.RULES}") 
@@ -46,6 +46,20 @@ class LintIntegrationTest {
                 .build('check')
 
         assertThat(result.logs).doesNotContainLimitExceeded()
+    }
+
+    @Test
+    void shouldNotFailBuildWhenLintIsConfiguredMultipleTimes() {
+        createAndroidProjectWith(Fixtures.Lint.SOURCES_WITH_WARNINGS, 1, 0)
+                .withToolsConfig("""
+                    lintOptions {              
+                        lintConfig = file("${Fixtures.Lint.RULES}") 
+                    }
+                    lintOptions {              
+                        checkReleaseBuilds false 
+                    }
+                    """)
+                .build('check', '--dry-run')
     }
 
     private static TestProject createAndroidProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {


### PR DESCRIPTION
Fixes #84 

### Problem

As described in #84, using `lintOptions` twice will fail configuration because our plugin tries to create the task multiple times. 

### Considerations

Android tools support having `lintOptions` defined more than once. This is useful when project has `lintOptions` in a common place and then another one specific to a submodule.

`maybeCreate` is used instead. Since maybeCreate does not have configure param, configuration is done separately.

`dry-run` options is used in test because this only tests the configuration and `dry-run` speeds the test execution.