### PR TITLE
rename failOnWarnings to failFast

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -50,10 +50,10 @@ Besides manually specifying thresholds, the plugin includes a few built-in `pena
     ```
     This will break the build if any error is found. Warnings instead are only logged and will not break the build.
 
-* `failOnWarnings`
+* `failFast`
     ```gradle
     staticAnalysis {
-        penalty failOnWarnings
+        penalty failFast
     }
     ```
     This policy will fail the build if any warning or error is found. It is a zero-tolerance policy, useful to keep

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisExtension.groovy
@@ -18,9 +18,15 @@ class StaticAnalysisExtension {
         it.maxErrors = 0
     }
 
-    final Action<? super PenaltyExtension> failOnWarnings = {
+    final Action<? super PenaltyExtension> failFast = {
         it.maxWarnings = 0
         it.maxErrors = 0
+    }
+
+    @Deprecated
+    def getFailOnWarnings() {
+        logger.warn 'com.novoda.static-analysis: failOnWarnings is deprecated. Please use `penalty failFast` for clarity.'
+        failFast
     }
 
     private final Project project


### PR DESCRIPTION
Fixes #87 

While working on documentation we realized that `failOnWarnings` is not super clear.

This PR replaces it with `failFast` for clarity. 

`failOnWarnings` is converted to read-only property method which should keep the API 100% the same but it allows us to log a warning and gives the users the opportunity to update their Gradle configuration without making the build fail.