### PR TITLE
Multiple config support for tools

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -80,9 +80,9 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
     }
 
     private CollectCheckstyleViolationsTask createCollectViolationsTask(Checkstyle checkstyle, Violations violations) {
-        project.tasks.create("collect${checkstyle.name.capitalize()}Violations", CollectCheckstyleViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = checkstyle.reports.xml.destination
-            collectViolations.violations = violations
-        }
+        def task = project.tasks.maybeCreate("collect${checkstyle.name.capitalize()}Violations", CollectCheckstyleViolationsTask)
+        task.xmlReportFile = checkstyle.reports.xml.destination
+        task.violations = violations
+        task
     }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -58,7 +58,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     @Override
     protected void configureAndroidVariant(variant) {
-        FindBugs task = project.tasks.create("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
+        FindBugs task = project.tasks.maybeCreate("findbugs${variant.name.capitalize()}", QuietFindbugsPlugin.Task)
         List<File> androidSourceDirs = variant.sourceSets.collect { it.javaDirectories }.flatten()
         task.with {
             description = "Run FindBugs analysis for ${variant.name} classes"
@@ -66,10 +66,10 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             classpath = variant.javaCompile.classpath
         }
         sourceFilter.applyTo(task)
-        task.conventionMapping.map("classes", {
+        task.conventionMapping.map("classes") {
             List<String> includes = createIncludePatterns(task.source, androidSourceDirs)
             getAndroidClasses(variant, includes)
-        })
+        }
         task.dependsOn variant.javaCompile
     }
 
@@ -140,19 +140,19 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     private CollectFindbugsViolationsTask createViolationsCollectionTask(FindBugs findBugs, Violations violations) {
-        project.tasks.create("collect${findBugs.name.capitalize()}Violations", CollectFindbugsViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = findBugs.reports.xml.destination
-            collectViolations.violations = violations
-        }
+        def task = project.tasks.maybeCreate("collect${findBugs.name.capitalize()}Violations", CollectFindbugsViolationsTask)
+        task.xmlReportFile = findBugs.reports.xml.destination
+        task.violations = violations
+        task
     }
 
     private GenerateFindBugsHtmlReport createHtmlReportTask(FindBugs findBugs, File xmlReportFile, File htmlReportFile) {
-        project.tasks.create("generate${findBugs.name.capitalize()}HtmlReport", GenerateFindBugsHtmlReport) { generateHtmlReport ->
-            generateHtmlReport.xmlReportFile = xmlReportFile
-            generateHtmlReport.htmlReportFile = htmlReportFile
-            generateHtmlReport.classpath = findBugs.findbugsClasspath
-            generateHtmlReport.onlyIf { xmlReportFile?.exists() }
-        }
+        def task = project.tasks.maybeCreate("generate${findBugs.name.capitalize()}HtmlReport", GenerateFindBugsHtmlReport)
+        task.xmlReportFile = xmlReportFile
+        task.htmlReportFile = htmlReportFile
+        task.classpath = findBugs.findbugsClasspath
+        task.onlyIf { xmlReportFile?.exists() }
+        task
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -82,10 +82,10 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
     }
 
     private CollectPmdViolationsTask createViolationsCollectionTask(Pmd pmd, Violations violations) {
-        project.tasks.create("collect${pmd.name.capitalize()}Violations", CollectPmdViolationsTask) { collectViolations ->
-            collectViolations.xmlReportFile = pmd.reports.xml.destination
-            collectViolations.violations = violations
-        }
+        def task = project.tasks.maybeCreate("collect${pmd.name.capitalize()}Violations", CollectPmdViolationsTask)
+        task.xmlReportFile = pmd.reports.xml.destination
+        task.violations = violations
+        task
     }
 
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
@@ -229,6 +229,22 @@ public class CheckstyleIntegrationTest {
                 result.buildFileUrl('reports/checkstyle/main.html'))
     }
 
+    @Test
+    void shouldNotFailBuildWhenCheckstyleIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('none')
+                .withToolsConfig("""  
+                    checkstyle {
+                        configFile new File('${Fixtures.Checkstyle.MODULES.path}') 
+                    }
+                    checkstyle {
+                        ignoreFailures = false
+                    }  
+                """)
+                .build('check', '--dry-run')
+    }
+
     private static String checkstyle(String configFile, String... configs) {
         """checkstyle {
             ${configFile}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -345,6 +345,20 @@ class FindbugsIntegrationTest {
         Truth.assertThat(result.outcome(':checkFindbugsClasses')).isEqualTo(TaskOutcome.SUCCESS)
     }
 
+    @Test
+    void shouldNotFailBuildWhenFindbugsIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withPenalty('none')
+                .withToolsConfig("""  
+                    findbugs { }
+                    findbugs {
+                        ignoreFailures = false
+                    }  
+                """)
+                .build('check')
+    }
+
     /**
      * The custom task created in the snippet below will check whether {@code Findbugs} tasks with
      * empty {@code source} will have empty {@code classes} too. </p>

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
@@ -213,6 +213,22 @@ public class PmdIntegrationTest {
         assertThat(result.logs).doesNotContainPmdViolations()
     }
 
+    @Test
+    void shouldNotFailBuildWhenPmdIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withPenalty('none')
+                .withToolsConfig("""  
+                    pmd {
+                        ruleSetFiles = $DEFAULT_RULES
+                    }
+                    pmd {
+                        ignoreFailures = false
+                    }  
+                """)
+                .build('check')
+    }
+
     private String pmd(String rules, String... configs) {
         """pmd {
             ruleSetFiles = $rules


### PR DESCRIPTION
Just like Android Lint, main tools (pmd, findbugs, checkstyle) also had the same problem where if the user configures them multiple times, the configuration fails. 

Tests were written first and then when `task already exists` problems happen, task creations are converted to `maybeCreate`