### PR TITLE
Feature: Add support for fatal lint

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTask.groovy
@@ -9,7 +9,7 @@ class CollectLintViolationsTask extends CollectViolationsTask {
     @Override
     void collectViolations(File xmlReportFile, File htmlReportFile, Violations violations) {
         GPathResult xml = new XmlSlurper().parse(xmlReportFile)
-        int errors = xml.'**'.findAll { node -> node.name() == 'issue' && node.@severity == 'Error' }.size()
+        int errors = xml.'**'.findAll { node -> node.name() == 'issue' && (node.@severity == 'Error' || node.@severity == 'Fatal') }.size()
         int warnings = xml.'**'.findAll { node -> node.name() == 'issue' && node.@severity == 'Warning' }.size()
         violations.addViolations(errors, warnings, htmlReportFile ?: xmlReportFile)
     }

--- a/plugin/src/test/fixtures/reports/lint/lint-results.xml
+++ b/plugin/src/test/fixtures/reports/lint/lint-results.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="4" by="lint 3.0.1">
 
+    <issue id="StopShip" severity="Fatal" message="Code contains STOPSHIP marker" category="Correctness"
+      priority="10" summary="Code contains STOPSHIP marker"/>
+
     <issue
         id="MissingSuperCall"
         severity="Error"

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/lint/CollectLintViolationsTaskTest.groovy
@@ -18,7 +18,7 @@ class CollectLintViolationsTaskTest {
         Violations violations = new Violations('Android Lint')
         task.collectViolations(Fixtures.Lint.SAMPLE_REPORT, null, violations)
 
-        assertThat(violations.getErrors()).isEqualTo(1)
+        assertThat(violations.getErrors()).isEqualTo(2)
         assertThat(violations.getWarnings()).isEqualTo(1)
     }
 }


### PR DESCRIPTION
Fatal lint errors currently do not contribute to our total error count.

This PR:
 - Adds in a fatal error to our lint results
 - Adds fatal errors to our total `errors` count
 - Modifies the integration test to reflect this