### PR TITLE
Gradle: Adding support for snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ staticAnalysis {
 This will enable all the tools with their default settings. For more advanced configurations, please refer to the
 [advanced usage](docs/advanced-usage.md) and to the [supported tools](docs/supported-tools.md) pages.
 
+## Snapshots
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=gradle-static-analysis-plugin-snapshot)](https://ci.novoda.com/job/gradle-static-analysis-plugin-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/gradle-static-analysis-plugin/images/download.svg)](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion)
+
+Snapshot builds from [`develop`](https://github.com/novoda/gradle-static-analysis-plugin/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion) that is not synced with JCenter.
+To consume a snapshot build add an additional maven repo as follows:
+```
+repositories {
+    maven {
+        url 'https://novoda.bintray.com/snapshots'
+    }
+}
+```
+
+You can find the latest snapshot version following this [link](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion).
+
+
 ## Roadmap
 The plugin is under active development and to be considered in **beta stage**. It is routinely used by many Novoda projects and
 by other external projects with no known critical issues. The API is supposed to be relatively stable, but there still may be

--- a/buildSrc/src/main/groovy/GradlePlugins.groovy
+++ b/buildSrc/src/main/groovy/GradlePlugins.groovy
@@ -1,6 +1,6 @@
 class GradlePlugins {
     final bintrayRelease = 'com.novoda:bintray-release:0.4.0'
-    final buildProperties = 'com.novoda:gradle-build-properties-plugin:0.2'
+    final buildProperties = 'com.novoda:gradle-build-properties-plugin:0.4.1'
     final gradleGit = 'org.ajoberstar:gradle-git:1.6.0'
     final gradlePublish = 'com.gradle.publish:plugin-publish-plugin:0.9.9'
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -10,14 +10,20 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.novoda.bintray-release'
 publish {
     userOrg = 'novoda'
+    repoName = 'maven'
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
-    publishVersion = project.version
+
+    version = buildProperties.publish['version'].string
+    publishVersion = buildProperties.publish['version'].string
+    bintrayUser = buildProperties.publish['bintrayUser'].string
+    bintrayKey = buildProperties.publish['bintrayKey'].string
     website = websiteUrl
 }
 
 apply plugin: 'com.novoda.build-properties'
 buildProperties {
+
     secrets {
         file(rootProject.file('secrets.properties'), '''
 This file should contain:
@@ -27,6 +33,34 @@ This file should contain:
 - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
 		''')
     }
+
+    cli {
+        using(project)
+    }
+
+    bintray {
+        def bintrayCredentials = {
+            boolean isDryRun = cli['dryRun'].or(true).boolean
+            return isDryRun ?
+                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
+        }
+        using(bintrayCredentials()).or(cli)
+        description = '''This should contain the following properties:
+                      | - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                      | - bintrayUser: name of the account used to deploy the artifacts
+                      | - bintrayKey: API key of the account used to deploy the artifacts
+        '''.stripMargin()
+    }
+
+    publish {
+        def generateVersion = {
+            boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
+            return isSnapshot ? "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
+        }
+        using(['version': "${generateVersion()}"]).or(buildProperties.bintray)
+    }
+
 }
 
 apply plugin: 'org.ajoberstar.grgit'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -50,6 +50,7 @@ This file should contain:
 
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.novoda.bintray-release'
+
 publish {
     userOrg = 'novoda'
     repoName = 'maven'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -26,8 +26,7 @@ buildProperties {
 
     bintray {
         def bintrayCredentials = {
-            boolean isDryRun = cli['dryRun'].or(true).boolean
-            return isDryRun ?
+            return isDryRun() ?
                     ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
                     new File("${System.getenv('BINTRAY_PROPERTIES')}")
         }
@@ -41,8 +40,7 @@ buildProperties {
 
     publish {
         def generateVersion = {
-            boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
-            return isSnapshot ? "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
+            return isSnapshot() ? "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
         }
         using(['version': "${generateVersion()}"]).or(buildProperties.bintray)
     }
@@ -165,13 +163,11 @@ task publishGroovydoc {
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
-    boolean isDryRun = buildProperties.cli['dryRun'].or(true).boolean
-    if (isDryRun) {
+    if (isDryRun()) {
         dependsOn publishArtifact
     } else {
         dependsOn publishArtifact
-        boolean isSnapshot = buildProperties.cli['bintraySnapshot'].or(false)
-        if (!isSnapshot) {
+        if (!isSnapshot()) {
             dependsOn prepareRelease, publishGroovydoc, publishPlugins
             doLast {
                 grgit.push {
@@ -180,4 +176,12 @@ task publishRelease {
             }
         }
     }
+}
+
+boolean isDryRun() {
+    buildProperties.cli['dryRun'].or(true).boolean
+}
+
+boolean isSnapshot() {
+    buildProperties.cli['bintraySnapshot'].or(false)
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -10,13 +10,14 @@ apply plugin: 'com.novoda.build-properties'
 buildProperties {
 
     secrets {
-        file(rootProject.file('secrets.properties'), '''
-This file should contain:
+        using rootProject.file('secrets.properties')
+        description = '''
+    This file should contain:
 - git.username: the username used to push to the repo
 - git.password: the password used to push to the repo
 - gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
 - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
-		''')
+		'''
     }
 
     cli {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -6,21 +6,6 @@ version = '0.5.2'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Static Analysis Plugin'
 
-apply plugin: 'com.gradle.plugin-publish'
-apply plugin: 'com.novoda.bintray-release'
-publish {
-    userOrg = 'novoda'
-    repoName = 'maven'
-    groupId = 'com.novoda'
-    artifactId = 'gradle-static-analysis-plugin'
-
-    version = buildProperties.publish['version'].string
-    publishVersion = buildProperties.publish['version'].string
-    bintrayUser = buildProperties.publish['bintrayUser'].string
-    bintrayKey = buildProperties.publish['bintrayKey'].string
-    website = websiteUrl
-}
-
 apply plugin: 'com.novoda.build-properties'
 buildProperties {
 
@@ -61,6 +46,21 @@ This file should contain:
         using(['version': "${generateVersion()}"]).or(buildProperties.bintray)
     }
 
+}
+
+apply plugin: 'com.gradle.plugin-publish'
+apply plugin: 'com.novoda.bintray-release'
+publish {
+    userOrg = 'novoda'
+    repoName = 'maven'
+    groupId = 'com.novoda'
+    artifactId = 'gradle-static-analysis-plugin'
+
+    version = project.buildProperties.publish['version'].string
+    publishVersion = project.buildProperties.publish['version'].string
+    bintrayUser = project.buildProperties.publish['bintrayUser'].string
+    bintrayKey = project.buildProperties.publish['bintrayKey'].string
+    website = websiteUrl
 }
 
 apply plugin: 'org.ajoberstar.grgit'
@@ -165,16 +165,14 @@ task publishRelease {
     group = 'release'
     boolean isDryRun = buildProperties.cli['dryRun'].or(true).boolean
     if (!isDryRun) {
-        dependsOn prepareRelease, publishArtifact, publishGroovydoc
-
+        dependsOn publishArtifact
         boolean isSnapshot = buildProperties.cli['bintraySnapshot'].or(false)
         if (!isSnapshot) {
-            dependsOn publishPlugins
-        }
-
-        doLast {
-            grgit.push {
-                tags = true
+            dependsOn prepareRelease, publishGroovydoc, publishPlugins
+            doLast {
+                grgit.push {
+                    tags = true
+                }
             }
         }
     } else {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -12,12 +12,12 @@ buildProperties {
     secrets {
         using rootProject.file('secrets.properties')
         description = '''
-This file should contain:
+    This file should contain:
 - git.username: the username used to push to the repo
 - git.password: the password used to push to the repo
 - gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
 - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
-'''
+		'''
     }
 
     cli {
@@ -183,5 +183,5 @@ boolean isDryRun() {
 }
 
 boolean isSnapshot() {
-    buildProperties.cli['bintraySnapshot'].or(false)
+    buildProperties.cli['bintraySnapshot'].or(false).boolean
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -165,7 +165,9 @@ task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
     boolean isDryRun = buildProperties.cli['dryRun'].or(true).boolean
-    if (!isDryRun) {
+    if (isDryRun) {
+        dependsOn publishArtifact
+    } else {
         dependsOn publishArtifact
         boolean isSnapshot = buildProperties.cli['bintraySnapshot'].or(false)
         if (!isSnapshot) {
@@ -176,7 +178,5 @@ task publishRelease {
                 }
             }
         }
-    } else {
-        dependsOn publishArtifact
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -163,8 +163,15 @@ task publishGroovydoc {
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
-    if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
-        dependsOn prepareRelease, publishArtifact, publishGroovydoc, publishPlugins
+    boolean isDryRun = buildProperties.cli['dryRun'].or(true).boolean
+    if (!isDryRun) {
+        dependsOn prepareRelease, publishArtifact, publishGroovydoc
+
+        boolean isSnapshot = buildProperties.cli['bintraySnapshot'].or(false)
+        if (!isSnapshot) {
+            dependsOn publishPlugins
+        }
+
         doLast {
             grgit.push {
                 tags = true


### PR DESCRIPTION
This PR adds support for snapshots builds

These will be built off the development branch 

We updated the `gradle-build-properties-plugin` to the latest version

Here is the link to the Jenkins job: https://ci.novoda.com/job/gradle-static-analysis-plugin-snapshot/

Paired with @tobiasheine 
