### PR TITLE
Snapshot: Using correct repo 

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -52,7 +52,7 @@ apply plugin: 'com.novoda.bintray-release'
 
 publish {
     userOrg = 'novoda'
-    repoName = 'maven'
+    repoName = buildProperties.publish['bintrayRepo'].string
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
 


### PR DESCRIPTION
Previously had the repo hardcoded to use maven. Now we inherit this value from the environment.
