### PR TITLE
Exclude kotlin files by default on java code quality tools.

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -83,7 +83,10 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     protected abstract void configureAndroidVariant(variant)
 
     protected void configureJavaProject() {
-        project.tasks.withType(taskClass) { task -> sourceFilter.applyTo(task) }
+        project.tasks.withType(taskClass) { task ->
+            sourceFilter.applyTo(task)
+            task.exclude '**/*.kt'
+        }
     }
 
     protected abstract Class<T> getTaskClass()

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -59,6 +59,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
                         description = "Run Checkstyle analysis for ${sourceSet.name} classes"
                         source = sourceSet.java.srcDirs
                         classpath = files("$buildDir/intermediates/classes/")
+                        exclude '**/*.kt'
                     }
                 }
                 sourceFilter.applyTo(task)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -64,6 +64,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             description = "Run FindBugs analysis for ${variant.name} classes"
             source = androidSourceDirs
             classpath = variant.javaCompile.classpath
+            exclude '**/*.kt'
         }
         sourceFilter.applyTo(task)
         task.conventionMapping.map("classes") {
@@ -90,6 +91,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
                         List<String> includes = createIncludePatterns(task.source, sourceDirs)
                         getJavaClasses(sourceSet, includes)
                     })
+                    task.exclude '**/*.kt'
                 }
             }
         }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -62,6 +62,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
                     task.with {
                         description = "Run PMD analysis for ${sourceSet.name} classes"
                         source = sourceSet.java.srcDirs
+                        exclude '**/*.kt'
                     }
                 }
                 sourceFilter.applyTo(task)


### PR DESCRIPTION
This PR adds a default exclusion for kotlin files on Checkstyle, Findbugs and PMD tools.

Note: Since `sample` is in master, I couldn't change it to reflect these changes. That needs to be updated separately. 

~Also update samples to remove redundant excludes.~

~Also fixes the detekt config not to fail so that the plugin handles violations. This is already the recommended approach in [our guides](https://github.com/tasomaniac/gradle-static-analysis-plugin/blob/master/docs/tools/detekt.md#configure-detekt). Sample should reflect that.~

Fixes #56 