### PR TITLE
Fix for newer Detekt versions

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -13,6 +13,7 @@ class DetektConfigurator implements Configurator {
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
     private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
     private static final String OUTPUT_NOT_DEFINED = 'Output not defined! To analyze the results, `output` needs to be defined in Detekt profile.'
+    private static final String DETEKT_CONFIGURATION_ERROR = 'A problem occurred while configuring Detekt. Please make sure to use a compatible version.'
 
     private final Project project
     private final Violations violations
@@ -53,9 +54,6 @@ class DetektConfigurator implements Configurator {
         def detektTask = project.tasks['detektCheck']
         detektTask.group = 'verification'
 
-        // run detekt as part of check
-        project.tasks['check'].dependsOn(detektTask)
-
         // evaluate violations after detekt
         def output = resolveOutput(detekt)
         if (!output) {
@@ -69,8 +67,10 @@ class DetektConfigurator implements Configurator {
     private static resolveOutput(detekt) {
         if (detekt.hasProperty('profileStorage')) {
             detekt.profileStorage.systemOrDefault.output
-        } else {
+        } else if (detekt.respondsTo('systemOrDefaultProfile')) {
             detekt.systemOrDefaultProfile().output
+        } else {
+            throw new IllegalStateException(DETEKT_CONFIGURATION_ERROR)
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -57,13 +57,21 @@ class DetektConfigurator implements Configurator {
         project.tasks['check'].dependsOn(detektTask)
 
         // evaluate violations after detekt
-        def output = detekt.systemOrDefaultProfile().output
+        def output = resolveOutput(detekt)
         if (!output) {
             throw new IllegalArgumentException(OUTPUT_NOT_DEFINED)
         }
         def collectViolations = createCollectViolationsTask(violations, project.file(output))
         evaluateViolations.dependsOn collectViolations
         collectViolations.dependsOn detektTask
+    }
+
+    private static resolveOutput(detekt) {
+        if (detekt.hasProperty('profileStorage')) {
+            detekt.profileStorage.systemOrDefault.output
+        } else {
+            detekt.systemOrDefaultProfile().output
+        }
     }
 
     private CollectDetektViolationsTask createCollectViolationsTask(Violations violations, File outputFolder) {

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -16,16 +16,23 @@ class DetektIntegrationTest {
     private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.'
     private static final String OUTPUT_NOT_DEFINED = 'Output not defined! To analyze the results, `output` needs to be defined in Detekt profile.'
 
-    @Parameterized.Parameters(name = "{0}")
-    static Iterable<TestProjectRule> rules() {
-        return [TestProjectRule.forKotlinProject(), TestProjectRule.forAndroidKotlinProject()]
+    @Parameterized.Parameters(name = "{0} with Detekt: {1}")
+    static Iterable rules() {
+        return [
+                [TestProjectRule.forKotlinProject(), "1.0.0.RC6-2"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.0.0.RC6-2"],
+                [TestProjectRule.forKotlinProject(), "1.0.0.RC8"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.0.0.RC8"],
+        ]*.toArray()
     }
 
     @Rule
     public final TestProjectRule projectRule
+    private final String detektVersion
 
-    DetektIntegrationTest(TestProjectRule projectRule) {
+    DetektIntegrationTest(TestProjectRule projectRule, String detektVersion) {
         this.projectRule = projectRule
+        this.detektVersion = detektVersion
     }
 
     @Test
@@ -97,7 +104,7 @@ class DetektIntegrationTest {
     @Test
     void shouldNotFailBuildWhenNoDetektWarningsOrErrorsEncounteredAndNoThresholdTrespassed() {
         def testProject = projectRule.newProject()
-                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
+                .withPlugin("io.gitlab.arturbosch.detekt", detektVersion)
                 .withPenalty('''{
                     maxWarnings = 0
                     maxErrors = 0
@@ -117,7 +124,7 @@ class DetektIntegrationTest {
 
     private TestProject createProjectWith(File sources, int maxWarnings = 0, int maxErrors = 0) {
         projectRule.newProject()
-                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
+                .withPlugin("io.gitlab.arturbosch.detekt", detektVersion)
                 .withSourceSet('main', sources)
                 .withPenalty("""{
                     maxWarnings = ${maxWarnings}
@@ -128,7 +135,7 @@ class DetektIntegrationTest {
 
     private TestProject createProjectWithoutDetekt() {
         projectRule.newProject()
-                .withPlugin("io.gitlab.arturbosch.detekt", "1.0.0.RC6-2")
+                .withPlugin("io.gitlab.arturbosch.detekt", detektVersion)
                 .withSourceSet('main', Fixtures.Detekt.SOURCES_WITH_WARNINGS)
                 .withPenalty('''{
                     maxWarnings = 0


### PR DESCRIPTION
## Problem

- `Profile` public property in Detekt extension was moved in `1.0.0-RC6.3`
  - This caused `systemOrDefaultProfile()` method call to fail as it is not available anymore. 

## Solution

Check if a property or method is available before calling it. 
If not available, throw a message. Feedback is welcome on the message itself. 

Also checked the whole integration. The rest seems to be fine. Only other thing that we access is the actual Gradle task name which is not likely to change. 

Also added tests to cover both Detekt versions.

Fixes #102