### PR TITLE
Prepare release 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Change Log
 ==========
 
+[Version 0.6](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.6)
+--------------------------
+
+- Fix release to plugin portal ([PR#82](https://github.com/novoda/gradle-static-analysis-plugin/pull/82),[PR#83](https://github.com/novoda/gradle-static-analysis-plugin/pull/83))
+- Improve plugin documentation and samples ([PR#85](https://github.com/novoda/gradle-static-analysis-plugin/pull/85),
+[PR#88](https://github.com/novoda/gradle-static-analysis-plugin/pull/88),
+[PR#97](https://github.com/novoda/gradle-static-analysis-plugin/pull/97),
+[PR#99](https://github.com/novoda/gradle-static-analysis-plugin/pull/99),
+[PR#100](https://github.com/novoda/gradle-static-analysis-plugin/pull/100),
+[PR#101](https://github.com/novoda/gradle-static-analysis-plugin/pull/101),
+[PR#113](https://github.com/novoda/gradle-static-analysis-plugin/pull/113),
+[PR#123](https://github.com/novoda/gradle-static-analysis-plugin/pull/123), 
+[PR#124](https://github.com/novoda/gradle-static-analysis-plugin/pull/124))
+- Improve support for Android Lint ([PR#89](https://github.com/novoda/gradle-static-analysis-plugin/pull/89), [PR#105](https://github.com/novoda/gradle-static-analysis-plugin/pull/105))
+- Improve support for Detekt ([PR#90](https://github.com/novoda/gradle-static-analysis-plugin/pull/90), [PR#121](https://github.com/novoda/gradle-static-analysis-plugin/pull/121))
+- Rename built-in `failOnWarnings` penalty to `failFast` ([PR#92](https://github.com/novoda/gradle-static-analysis-plugin/pull/92))
+- Support multiple configurations for `Pmd`, `Findbugs`, `Checkstyle` ([PR#93](https://github.com/novoda/gradle-static-analysis-plugin/pull/93))
+- Support automatic snapshot builds from `develop` ([PR#106](https://github.com/novoda/gradle-static-analysis-plugin/pull/106),[PR#107](https://github.com/novoda/gradle-static-analysis-plugin/pull/107))
+- Automatically exclude Kotlin files from Java code quality tools ([PR#109](https://github.com/novoda/gradle-static-analysis-plugin/pull/109))
+- Integrate [KtLint](https://github.com/shyiko/ktlint) ([PR#110](https://github.com/novoda/gradle-static-analysis-plugin/pull/110))
+
 [Version 0.5.2](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.5.2)
 --------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Change Log
 
 - Fix release to plugin portal ([PR#82](https://github.com/novoda/gradle-static-analysis-plugin/pull/82),[PR#83](https://github.com/novoda/gradle-static-analysis-plugin/pull/83))
 - Improve plugin documentation and samples ([PR#85](https://github.com/novoda/gradle-static-analysis-plugin/pull/85),
-[PR#88](https://github.com/novoda/gradle-static-analysis-plugin/pull/88),
 [PR#97](https://github.com/novoda/gradle-static-analysis-plugin/pull/97),
 [PR#99](https://github.com/novoda/gradle-static-analysis-plugin/pull/99),
 [PR#100](https://github.com/novoda/gradle-static-analysis-plugin/pull/100),
@@ -14,7 +13,7 @@ Change Log
 [PR#113](https://github.com/novoda/gradle-static-analysis-plugin/pull/113),
 [PR#123](https://github.com/novoda/gradle-static-analysis-plugin/pull/123), 
 [PR#124](https://github.com/novoda/gradle-static-analysis-plugin/pull/124))
-- Improve support for Android Lint ([PR#89](https://github.com/novoda/gradle-static-analysis-plugin/pull/89), [PR#105](https://github.com/novoda/gradle-static-analysis-plugin/pull/105))
+- Improve support for Android Lint ([PR#105](https://github.com/novoda/gradle-static-analysis-plugin/pull/105))
 - Improve support for Detekt ([PR#90](https://github.com/novoda/gradle-static-analysis-plugin/pull/90), [PR#121](https://github.com/novoda/gradle-static-analysis-plugin/pull/121))
 - Rename built-in `failOnWarnings` penalty to `failFast` ([PR#92](https://github.com/novoda/gradle-static-analysis-plugin/pull/92))
 - Support multiple configurations for `Pmd`, `Findbugs`, `Checkstyle` ([PR#93](https://github.com/novoda/gradle-static-analysis-plugin/pull/93))

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.5.2'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
     }
 }
 
@@ -55,7 +55,7 @@ or from the [Gradle Plugins Repository](https://plugins.gradle.org/):
 
 ```gradle
 plugins {
-    id 'com.novoda.static-analysis' version '0.5.2'
+    id 'com.novoda.static-analysis' version '0.6'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ The plugin supports various static analysis tools for Java, Kotlin and Android p
  * [`FindBugs`](http://findbugs.sourceforge.net/)
  * [`Detekt`](https://github.com/arturbosch/detekt)
  * [`Android Lint`](https://developer.android.com/studio/write/lint.html)
-
-Support for additional tools is planned but not available yet:
-
  * [`KtLint`](https://github.com/shyiko/ktlint)
  
 Please note that the tools availability depends on the project the plugin is applied to. For more details please refer to the

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,7 +2,7 @@ ext {
     websiteUrl = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 
-version = '0.5.2'
+version = '0.6'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Static Analysis Plugin'
 


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin with all the changes already available in [`SNAPSHOT-10`](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/SNAPSHOT-10). Once this is reviewed and merged we will trigger the proper release.

## Considerations and implementation
- Updated `CHANGELOG`
- Bumped version for release

@tasomaniac @tobiasheine @rock3r: please take a look and tell if anything is missing.
