### PR TITLE
PT-821: Downgrade Gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -34,6 +34,9 @@ android {
         versionCode 1
         versionName '1.0'
     }
+    lintOptions {
+        disable 'OldTargetApi'
+    }
     sourceSets {
         ${formatSourceSets(project)}
     }

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -30,6 +30,9 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
+    }                   
+    lintOptions {
+        disable 'OldTargetApi'
     }
     sourceSets {
         ${formatSourceSets(project)}


### PR DESCRIPTION
Tracked in JIRA as [PT-821](https://novoda.atlassian.net/browse/PT-821)

**Description**
Upgrading Gradle from `4.4.1` to `4.9` broke the release.

**Considerations**
As quick-fix, we will downgrade Gradle back to `4.4.1`.

**Tests**
Verified manually using the `dry-run` property that all fields are set correct to the `publish` closure.