### PR TITLE
Fix some ktlint issues

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -119,8 +119,9 @@ class DetektConfigurator implements Configurator {
         final boolean isKotlin = project.plugins.hasPlugin('kotlin')
         final boolean isKotlinAndroid = project.plugins.hasPlugin('kotlin-android')
         final boolean isKotlinPlatformCommon = project.plugins.hasPlugin('kotlin-platform-common')
+        final boolean isKotlinMultiplatform = project.plugins.hasPlugin('org.jetbrains.kotlin.multiplatform')
         final boolean isKotlinPlatformJvm = project.plugins.hasPlugin('kotlin-platform-jvm')
         final boolean isKotlinPlatformJs = project.plugins.hasPlugin('kotlin-platform-js')
-        return isKotlin || isKotlinAndroid || isKotlinPlatformCommon || isKotlinPlatformJvm || isKotlinPlatformJs
+        return isKotlin || isKotlinAndroid || isKotlinPlatformCommon || isKotlinMultiplatform || isKotlinPlatformJvm || isKotlinPlatformJs
     }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -61,6 +61,9 @@ class KtlintConfigurator implements Configurator {
                 project.plugins.withId("kotlin-platform-common") {
                     configureKotlinProject()
                 }
+                project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
+                    configureKotlinProject()
+                }
                 project.plugins.withId('com.android.application') {
                     configureAndroidWithVariants(variantFilter.filteredApplicationVariants)
                 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -35,9 +35,12 @@ class KtlintIntegrationTest {
                 [TestProjectRule.forKotlinProject(), '5.1.0', 'ktlint-main.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '5.1.0', 'ktlint-debug.txt'],
                 [TestProjectRule.forKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
-//                [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintDebugCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
-//                [TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintDebugCheck.txt'],
+                /**
+                 * Tracked in https://github.com/novoda/gradle-static-analysis-plugin/issues/146
+                 */
+                //[TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintDebugCheck.txt'],
+                //[TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintDebugCheck.txt'],
         ]*.toArray()
     }
 
@@ -104,7 +107,7 @@ class KtlintIntegrationTest {
     void shouldNotFailBuildWhenNoErrorsEncounteredAndNoThresholdTrespassed() {
         def result = createProjectWith(Fixtures.Ktlint.SOURCES_NO_ERROR, 0)
                 .withToolsConfig(DEFAULT_CONFIG)
-                .build('evaluateViolations', '-s')
+                .build('evaluateViolations')
 
         assertThat(result.logs).doesNotContainLimitExceeded()
         assertThat(result.logs).doesNotContainKtlintViolations()

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -24,18 +24,24 @@ class KtlintIntegrationTest {
     @Parameterized.Parameters(name = '{0}')
     static def rules() {
         return [
-                [TestProjectRule.forKotlinProject(), 'main'].toArray(),
-                [TestProjectRule.forAndroidKotlinProject(), 'debug'].toArray()
+                [TestProjectRule.forKotlinProject(), 'main', '4.1.0'].toArray(),
+                [TestProjectRule.forAndroidKotlinProject(), 'debug', '4.1.0'].toArray(),
+                [TestProjectRule.forKotlinProject(), 'main', '5.1.0'].toArray(),
+                [TestProjectRule.forAndroidKotlinProject(), 'debug', '5.1.0'].toArray(),
+                [TestProjectRule.forKotlinProject(), 'main', '6.3.0'].toArray(),
+                [TestProjectRule.forAndroidKotlinProject(), 'debug', '6.3.0'].toArray(),
         ]
     }
 
     @Rule
     public final TestProjectRule projectRule
-    private final String sourceSetName;
+    private final String sourceSetName
+    private final String ktlintVersion
 
-    KtlintIntegrationTest(TestProjectRule projectRule, String sourceSetName) {
+    KtlintIntegrationTest(TestProjectRule projectRule, String sourceSetName, String ktlintVersion) {
         this.projectRule = projectRule
         this.sourceSetName = sourceSetName
+        this.ktlintVersion = ktlintVersion
     }
 
     @Test
@@ -88,7 +94,7 @@ class KtlintIntegrationTest {
 
     private TestProject createProjectWith(File sources, int maxErrors = 0) {
         projectRule.newProject()
-                .withPlugin('org.jlleitschuh.gradle.ktlint', '4.1.0')
+                .withPlugin('org.jlleitschuh.gradle.ktlint', ktlintVersion)
                 .withSourceSet('main', sources)
                 .withPenalty("""{
                     maxWarnings = 0

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -26,7 +26,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 16

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -23,7 +23,6 @@ repositories {
 apply plugin: 'com.android.library'
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Tried to fix some ktlint issues. 

- Added tests for different versions
- Automatically resolve the output files name from the task. File names have been changed but not this property. 
- Removed automatic adding of `CHECKSTYLE` reporter since passing String is not supported anymore and we cannot really reference their enum type in our integration. 
  - That's why now, we will require users to manually add `CHECKSTYLE` in their config.
  - Our integration will crash with a good message if it is missing. 

Problems: 
- Only for Android projects, for some reason `ktlintCheck` task give `NO-SOURCE` no matter I tried. Will spend some more time later.