### PR TITLE
Fix ktlint for all versions

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -97,12 +97,19 @@ class KtlintConfigurator implements Configurator {
 
     private void configureKtlint(String sourceSetName) {
         project.tasks.matching {
-            it.name == "ktlint${sourceSetName.capitalize()}Check"
+            isKtlintTask(it, sourceSetName.capitalize())
         }.all { Task ktlintTask ->
             def collectViolations = configureKtlintWithOutputFiles(sourceSetName, ktlintTask.reportOutputFiles)
             collectViolations.dependsOn ktlintTask
             evaluateViolations.dependsOn collectViolations
         }
+    }
+
+    /**
+     * KtLint task has the following naming convention and the needed property to resolve the reportOutputFiles
+     */
+    private boolean isKtlintTask(Task task, String sourceSetName) {
+        task.name ==~ /^ktlint$sourceSetName(SourceSet)?Check$/ && task.hasProperty('reportOutputFiles')
     }
 
     private def configureKtlintWithOutputFiles(String sourceSetName, Map<?, RegularFileProperty> reportOutputFiles) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -93,7 +93,6 @@ class KtlintConfigurator implements Configurator {
         variant.sourceSets.each { sourceSet ->
             configureKtlint(sourceSet.name)
         }
-        configureKtlint(variant.name)
     }
 
     private void configureKtlint(String sourceSetName) {

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -35,12 +35,12 @@ class KtlintIntegrationTest {
                 [TestProjectRule.forKotlinProject(), '5.1.0', 'ktlint-main.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '5.1.0', 'ktlint-debug.txt'],
                 [TestProjectRule.forKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
+                // Fails for our test setup since we have custom sourceDirs. https://github.com/JLLeitschuh/ktlint-gradle/issues/153
+                // [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintDebugCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
-                /**
-                 * Tracked in https://github.com/novoda/gradle-static-analysis-plugin/issues/146
-                 */
-                //[TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintDebugCheck.txt'],
-                //[TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintDebugCheck.txt'],
+                [TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
+                [TestProjectRule.forKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
+                [TestProjectRule.forAndroidKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
         ]*.toArray()
     }
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -35,8 +35,7 @@ class KtlintIntegrationTest {
                 [TestProjectRule.forKotlinProject(), '5.1.0', 'ktlint-main.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '5.1.0', 'ktlint-debug.txt'],
                 [TestProjectRule.forKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
-                // Fails for our test setup since we have custom sourceDirs. https://github.com/JLLeitschuh/ktlint-gradle/issues/153
-                // [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintDebugCheck.txt'],
+                [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
@@ -116,7 +115,7 @@ class KtlintIntegrationTest {
     private TestProject createProjectWith(File sources, int maxErrors = 0) {
         projectRule.newProject()
                 .withPlugin('org.jlleitschuh.gradle.ktlint', ktlintVersion)
-                .withSourceSet('main', sources)
+                .copyIntoSourceSet('main', sources)
                 .withPenalty("""{
                     maxWarnings = 0
                     maxErrors = ${maxErrors}

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -63,6 +63,13 @@ ${project.additionalConfiguration}
         file.text = text
     }
 
+    public T copyIntoSourceSet(String sourceSet, File srcDir) {
+        srcDir.listFiles().each {
+            withFile(it, "src/${sourceSet}/java/${it.name}")
+        }
+        return this
+    }
+
     public T withSourceSet(String sourceSet, File... srcDirs) {
         sourceSets[sourceSet] = srcDirs
         return this


### PR DESCRIPTION
Ktlint integration is fixed for 6.x  and upcoming 7.x versions. 

For Ktlint integration, we only depend on task names and a certain property (`reportOutputFiles`). Extracted task `matching` into a function and support resolving the tasks from all versions of ktlint.

## Tests

~6.1.0 is also fixed but has a bug affecting our test setup. I don't think it is worth to fix that only for tests. 6.2.x and 6.3.x are supported.~

Also enabled tests for `6.1.0` version by allowing test fixtures to be copied into the actual test project.