### PR TITLE
Make Findbugs Html report optional

### DIFF
--- a/docs/tools/findbugs.md
+++ b/docs/tools/findbugs.md
@@ -17,6 +17,7 @@ findbugs {
     toolVersion // A string, most likely '3.0.1' — the latest Findbugs release (for a long time)
     exclude // A fileTree, such as project.fileTree('src/test/java') to exclude Java unit tests
     excludeFilter // A file containing the Findbugs exclusions, e.g., teamPropsFile('static-analysis/findbugs-excludes.xml')
+    htmlReportEnabled true // Control whether html report generation should be enabled. `true` by default.
     includeVariants { variant -> ... } // A closure to determine which variants (for Android) to include
 }
 ```

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -73,10 +73,8 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
     protected abstract Class<E> getExtensionClass()
 
     protected Action<E> getDefaultConfiguration() {
-        new Action<E>() {
-            void execute(E ignored) {
-                // no op
-            }
+        return { ignored ->
+            // no op
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -3,7 +3,10 @@ package com.novoda.staticanalysis.internal.checkstyle
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import com.novoda.staticanalysis.internal.QuietLogger
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension
 
@@ -34,11 +37,8 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
 
     @Override
     protected Action<CheckstyleExtension> getDefaultConfiguration() {
-        new Action<CheckstyleExtension>() {
-            @Override
-            void execute(CheckstyleExtension checkstyleExtension) {
-                checkstyleExtension.toolVersion = '7.1.2'
-            }
+        return { extension ->
+            extension.toolVersion = '7.1.2'
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -2,7 +2,10 @@ package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.quality.FindBugs
@@ -12,6 +15,8 @@ import org.gradle.api.tasks.SourceSet
 import java.nio.file.Path
 
 class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {
+
+    protected boolean htmlReportEnabled = true
 
     static FindbugsConfigurator create(Project project,
                                        NamedDomainObjectContainer<Violations> violationsContainer,
@@ -48,11 +53,9 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     @Override
     protected Action<FindBugsExtension> getDefaultConfiguration() {
-        new Action<FindBugsExtension>() {
-            @Override
-            void execute(FindBugsExtension findBugsExtension) {
-                findBugsExtension.toolVersion = '3.0.1'
-            }
+        return { extension ->
+            extension.ext.htmlReportEnabled = { boolean enabled -> this.htmlReportEnabled = enabled }
+            extension.toolVersion = '3.0.1'
         }
     }
 
@@ -134,11 +137,15 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         findBugs.reports.html.enabled = false
 
         def collectViolations = createViolationsCollectionTask(findBugs, violations)
-        def generateHtmlReport = createHtmlReportTask(findBugs, collectViolations.xmlReportFile, collectViolations.htmlReportFile)
-
         evaluateViolations.dependsOn collectViolations
-        collectViolations.dependsOn generateHtmlReport
-        generateHtmlReport.dependsOn findBugs
+
+        if (htmlReportEnabled) {
+            def generateHtmlReport = createHtmlReportTask(findBugs, collectViolations.xmlReportFile, collectViolations.htmlReportFile)
+            collectViolations.dependsOn generateHtmlReport
+            generateHtmlReport.dependsOn findBugs
+        } else {
+            collectViolations.dependsOn findBugs
+        }
     }
 
     private CollectFindbugsViolationsTask createViolationsCollectionTask(FindBugs findBugs, Violations violations) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -42,12 +42,9 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
     @Override
     protected Action<PmdExtension> getDefaultConfiguration() {
-        new Action<PmdExtension>() {
-            @Override
-            void execute(PmdExtension pmdExtension) {
-                pmdExtension.toolVersion = '5.5.1'
-                pmdExtension.rulePriority = 5
-            }
+        return { extension ->
+            extension.toolVersion = '5.5.1'
+            extension.rulePriority = 5
         }
     }
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -363,12 +363,7 @@ class FindbugsIntegrationTest {
     @Test
     void shouldBeUpToDateWhenCheckTaskRunsAgain() {
         def project = projectRule.newProject()
-                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
-                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
-                .withPenalty('''{
-                    maxErrors = 10
-                    maxWarnings = 10
-                }''')
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
                 .withToolsConfig('findbugs {}')
 
         project.build('check')
@@ -382,12 +377,7 @@ class FindbugsIntegrationTest {
     @Test
     void shouldNotGenerateHtmlWhenDisabled() {
         def result = projectRule.newProject()
-                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
-                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
-                .withPenalty('''{
-                    maxErrors = 10
-                    maxWarnings = 10
-                }''')
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
                 .withToolsConfig('''findbugs { 
                     htmlReportEnabled false 
                 }''')

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -363,7 +363,12 @@ class FindbugsIntegrationTest {
     @Test
     void shouldBeUpToDateWhenCheckTaskRunsAgain() {
         def project = projectRule.newProject()
-                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)	                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)	
+                .withPenalty('''{	
+                    maxErrors = 10	
+                    maxWarnings = 10	
+                }''')
                 .withToolsConfig('findbugs {}')
 
         project.build('check')

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -351,11 +351,11 @@ class FindbugsIntegrationTest {
         projectRule.newProject()
                 .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
                 .withPenalty('none')
-                .withToolsConfig("""  
+                .withToolsConfig("""
                     findbugs { }
                     findbugs {
                         ignoreFailures = false
-                    }  
+                    }
                 """)
                 .build('check')
     }
@@ -377,6 +377,23 @@ class FindbugsIntegrationTest {
 
         Truth.assertThat(result.outcome(':findbugsDebug')).isEqualTo(TaskOutcome.UP_TO_DATE)
         Truth.assertThat(result.outcome(':generateFindbugsDebugHtmlReport')).isEqualTo(TaskOutcome.UP_TO_DATE)
+    }
+
+    @Test
+    void shouldNotGenerateHtmlWhenDisabled() {
+        def result = projectRule.newProject()
+                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 10
+                    maxWarnings = 10
+                }''')
+                .withToolsConfig('''findbugs { 
+                    htmlReportEnabled false 
+                }''')
+                .build('check')
+
+        Truth.assertThat(result.tasksPaths).doesNotContain(':generateFindbugsDebugHtmlReport')
     }
 
     /**

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -363,11 +363,11 @@ class FindbugsIntegrationTest {
     @Test
     void shouldBeUpToDateWhenCheckTaskRunsAgain() {
         def project = projectRule.newProject()
-                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)	                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
-                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)	
-                .withPenalty('''{	
-                    maxErrors = 10	
-                    maxWarnings = 10	
+                .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 10
+                    maxWarnings = 10
                 }''')
                 .withToolsConfig('findbugs {}')
 


### PR DESCRIPTION
Added `htmlReportEnabled` to the DSL to control whether we should generate html report or not. 

Initially I wanted to use `reports.html.enabled` but that is not available. `FindbugsExtension` is pretty limited and unfortunately does not have that built-in. It is in `Findbugs` task and to be able to use that we would require users to use something like `tasks.withType(Findbugs) { reports.html.enabled = false }` which is ugly.

Fixes #117 