### PR TITLE
Fix for files not being in the srcDirs

### DIFF
--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -36,8 +36,8 @@ android {
     lintOptions {
         disable 'OldTargetApi'
     }
-    sourceSets {
-        ${formatSourceSets(project)}
+    sourceSets.main {
+        manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
     }
     ${project.additionalAndroidConfig}
 }
@@ -53,20 +53,6 @@ ${formatExtension(project)}
         if (localProperties.exists()) {
             withFile(localProperties, 'local.properties')
         }
-    }
-
-    private static String formatSourceSets(TestProject project) {
-        project.sourceSets
-                .entrySet()
-                .collect { Map.Entry<String, List<String>> entry ->
-            """$entry.key {
-            manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
-            java {
-                ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
-            }
-        }"""
-        }
-        .join('\n\t\t')
     }
 
     @Override

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -33,8 +33,8 @@ android {
     lintOptions {
         disable 'OldTargetApi'
     }
-    sourceSets {
-        ${formatSourceSets(project)}
+    sourceSets.main {
+        manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
     }
     ${project.additionalAndroidConfig}
 }
@@ -50,20 +50,6 @@ ${formatExtension(project)}
         if (localProperties.exists()) {
             withFile(localProperties, 'local.properties')
         }
-    }
-
-    private static String formatSourceSets(TestProject project) {
-        project.sourceSets
-                .entrySet()
-                .collect { Map.Entry<String, List<String>> entry ->
-            """$entry.key {
-            manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
-            java {
-                ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
-            }
-        }"""
-        }
-        .join('\n\t\t')
     }
 
     TestAndroidProject withAdditionalAndroidConfig(String additionalAndroidConfig) {

--- a/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestJavaProject.groovy
@@ -12,27 +12,11 @@ repositories {
     jcenter()
 }
 apply plugin: 'java'
-sourceSets {
-    ${formatSourceSets(project)}
-}
 ${formatExtension(project)}
 """
     }
 
     TestJavaProject() {
         super(TEMPLATE)
-    }
-
-    private static String formatSourceSets(TestProject project) {
-        project.sourceSets
-                .entrySet()
-                .collect { Map.Entry<String, List<String>> entry ->
-            """$entry.key {
-        java {
-            ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
-        }
-    }"""
-        }
-        .join('\n\t')
     }
 }

--- a/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
@@ -24,9 +24,6 @@ repositories {
     jcenter()
 }
 
-sourceSets {
-    ${formatSourceSets(project)}
-}
 ${formatExtension(project)}
 """
     }
@@ -35,16 +32,4 @@ ${formatExtension(project)}
         super(TEMPLATE)
     }
 
-    private static String formatSourceSets(TestProject project) {
-        project.sourceSets
-                .entrySet()
-                .collect { Map.Entry<String, List<String>> entry ->
-            """$entry.key {
-        kotlin {
-            ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}
-        }
-    }"""
-        }
-        .join('\n\t')
-    }
 }

--- a/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -21,7 +21,6 @@ ${project.additionalConfiguration}
     private final GradleRunner gradleRunner
     private final Closure<String> template
     String additionalConfiguration = ''
-    Map<String, List<File>> sourceSets = [main: []]
     List<String> plugins = []
     String penalty
     String toolsConfig = ''
@@ -64,9 +63,14 @@ ${project.additionalConfiguration}
     }
 
     public T withSourceSet(String sourceSet, File... srcDirs) {
-        sourceSets[sourceSet] = srcDirs
+        srcDirs.collectMany {
+            it.listFiles() as List<File>
+        }.each {
+            withFile(it, "src/${sourceSet}/java/${it.name}")
+        }
         return this
     }
+
 
     public T withPenalty(String penalty) {
         this.penalty = "penalty $penalty"


### PR DESCRIPTION
Right now, we put the following into Test Project setup to create the test projects:

```
sourceSets { 
    main {
        srcDir full/path/to/folder/with/fixtures
    }
}
```

This folder is outside of the created test project. In real projects, this rarely happens. And this has caused problems couple of times with the tests (in some instances they're actual bugs in the tools).

With this PR, we now copy the whole file(s) into respective `sourceSet` folder.