### PR TITLE
Small adjustments to the output

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
@@ -17,22 +17,21 @@ class DefaultViolationsEvaluator implements ViolationsEvaluator {
 
     @Override
     void evaluate(Set<Violations> allViolations) {
-        Map<String, Integer> total = [errors: 0, warnings: 0]
         String fullMessage = ''
         allViolations.each { Violations violations ->
             if (!violations.isEmpty()) {
                 fullMessage += "> ${getViolationsMessage(violations, reportUrlRenderer)}\n"
             }
         }
-        total['errors'] = allViolations.collect { it.errors }.sum() as int
-        total['warnings'] = allViolations.collect { it.warnings }.sum() as int
+        int totalErrors = allViolations.collect { it.errors }.sum() as int
+        int totalWarnings = allViolations.collect { it.warnings }.sum() as int
 
-        int errorsDiff = Math.max(0, total['errors'] - penalty.maxErrors)
-        int warningsDiff = Math.max(0, total['warnings'] - penalty.maxWarnings)
+        int errorsDiff = Math.max(0, totalErrors - penalty.maxErrors)
+        int warningsDiff = Math.max(0, totalWarnings - penalty.maxWarnings)
         if (errorsDiff > 0 || warningsDiff > 0) {
             throw new GradleException("Violations limit exceeded by $errorsDiff errors, $warningsDiff warnings.\n\n$fullMessage")
         } else if (!fullMessage.isEmpty()) {
-            logger.warn "\n$fullMessage"
+            logger.warn "\nViolations found ($totalErrors errors, $totalWarnings warnings)\n\n$fullMessage"
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluator.groovy
@@ -18,7 +18,7 @@ class DefaultViolationsEvaluator implements ViolationsEvaluator {
     @Override
     void evaluate(Set<Violations> allViolations) {
         Map<String, Integer> total = [errors: 0, warnings: 0]
-        String fullMessage = '\n'
+        String fullMessage = ''
         allViolations.each { Violations violations ->
             if (!violations.isEmpty()) {
                 fullMessage += "> ${getViolationsMessage(violations, reportUrlRenderer)}\n"
@@ -30,9 +30,9 @@ class DefaultViolationsEvaluator implements ViolationsEvaluator {
         int errorsDiff = Math.max(0, total['errors'] - penalty.maxErrors)
         int warningsDiff = Math.max(0, total['warnings'] - penalty.maxWarnings)
         if (errorsDiff > 0 || warningsDiff > 0) {
-            throw new GradleException("Violations limit exceeded by $errorsDiff errors, $warningsDiff warnings.\n$fullMessage")
-        } else {
-            logger.warn fullMessage
+            throw new GradleException("Violations limit exceeded by $errorsDiff errors, $warningsDiff warnings.\n\n$fullMessage")
+        } else if (!fullMessage.isEmpty()) {
+            logger.warn "\n$fullMessage"
         }
     }
 

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluatorTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/DefaultViolationsEvaluatorTest.groovy
@@ -43,7 +43,9 @@ class DefaultViolationsEvaluatorTest {
 
         evaluator.evaluate(allViolations)
 
-        def expected = """
+        def expected = """    
+            Violations found (1 errors, 0 warnings)
+            
             > $TOOL_NAME violations found (1 errors, 0 warnings). See the reports at:
             - $consoleClickableFileUrl
             """

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -44,10 +44,6 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         check().that(actual().output)
     }
 
-    public void isEmpty() {
-        outputSubject.isEmpty()
-    }
-
     public void contains(log) {
         outputSubject.contains(log)
     }

--- a/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -44,6 +44,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         check().that(actual().output)
     }
 
+    public void isEmpty() {
+        outputSubject.isEmpty()
+    }
+
     public void contains(log) {
         outputSubject.contains(log)
     }


### PR DESCRIPTION
Fix empty space problem with the output. Verified that successful builds/checks wouldn't output anything at all on a multi-module environment.

Also fixes an old issue #19 where we put the total number of issues even when the task is successful. Will help getting an idea when there are too many warnings.

Also modified the tests to test the whole message.

Fixes #155 #19 