### PR TITLE
Less verbose Findbugs output

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -67,6 +67,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
             description = "Run FindBugs analysis for ${variant.name} classes"
             source = androidSourceDirs
             classpath = variant.javaCompile.classpath
+            extraArgs '-auxclasspath', androidJar
             exclude '**/*.kt'
         }
         sourceFilter.applyTo(task)
@@ -164,4 +165,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         task
     }
 
+    private def getAndroidJar() {
+        "${project.android.sdkDirectory}/platforms/${project.android.compileSdkVersion}/android.jar"
+    }
 }


### PR DESCRIPTION
I was looking at #33 and realized that I've been seeing Android classes in the output of Findbugs.

It turns out that these are called `auxclass` since they are not available to findbugs. Adding `auxclass` parameter removes these warnings and the output becomes less verbose

Before | After
------ | ------
| ![image](https://user-images.githubusercontent.com/763339/49832849-1c82f180-fd98-11e8-92f4-2bc25e282add.png) | ![image](https://user-images.githubusercontent.com/763339/49832812-08d78b00-fd98-11e8-96e6-e568355b29e6.png) |
