### PR TITLE
WIP: Task Configuration Avoidance

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/ToolTriggerTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/ToolTriggerTask.groovy
@@ -1,0 +1,9 @@
+package com.novoda.staticanalysis
+
+import org.gradle.api.DefaultTask
+
+/**
+ * Marker class to trigger tool tasks
+ */
+class ToolTriggerTask extends DefaultTask {
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -5,7 +5,6 @@ import com.novoda.staticanalysis.Violations
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.tasks.SourceTask
 
@@ -13,14 +12,12 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
 
     protected final Project project
     protected final Violations violations
-    protected final Task evaluateViolations
     protected final SourceFilter sourceFilter
     protected final VariantFilter variantFilter
 
-    protected CodeQualityConfigurator(Project project, Violations violations, Task evaluateViolations) {
+    protected CodeQualityConfigurator(Project project, Violations violations) {
         this.project = project
         this.violations = violations
-        this.evaluateViolations = evaluateViolations
         this.sourceFilter = new SourceFilter(project)
         this.variantFilter = new VariantFilter(project)
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/TasksCompat.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/TasksCompat.groovy
@@ -25,6 +25,14 @@ class TasksCompat {
         }
     }
 
+    static <T extends Task> Object createTask(Project project, String name, Class<T> type, Action<? super T> configuration) {
+        if (IS_GRADLE_MIN_49) {
+            return project.tasks.register(name, type, configuration)
+        } else {
+            return project.tasks.create(name, type, configuration)
+        }
+    }
+
     static <T extends Task> void configureEach(TaskCollection<T> tasks, Action<? super T> configuration) {
         if (IS_GRADLE_MIN_49) {
             tasks.all(configuration)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/TasksCompat.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/TasksCompat.groovy
@@ -1,0 +1,36 @@
+package com.novoda.staticanalysis.internal
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.tasks.TaskCollection
+import org.gradle.util.GradleVersion
+
+class TasksCompat {
+
+    private static boolean IS_GRADLE_MIN_49 = GradleVersion.current() >= GradleVersion.version("4.9")
+
+    static <T extends Task> Object maybeCreateTask(Project project, String name, Class<T> type, Action<? super T> configuration) {
+        if (IS_GRADLE_MIN_49) {
+            try {
+                def provider = project.tasks.named(name)
+                provider.configure(configuration)
+                return provider
+            } catch (UnknownTaskException ignored) {
+                return project.tasks.register(name, type, configuration)
+            }
+        } else {
+            return project.tasks.maybeCreate(name, type).configure(configuration)
+        }
+    }
+
+    static <T extends Task> void configureEach(TaskCollection<T> tasks, Action<? super T> configuration) {
+        if (IS_GRADLE_MIN_49) {
+            tasks.all(configuration)
+        } else {
+            tasks.all(configuration)
+        }
+    }
+
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -51,19 +51,14 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
 
     @Override
     protected void configureAndroidVariant(variant) {
-        project.with {
-            variant.sourceSets.each { sourceSet ->
-                def taskName = "checkstyle${sourceSet.name.capitalize()}"
-                Checkstyle task = tasks.findByName(taskName)
-                if (task == null) {
-                    task = tasks.create(taskName, Checkstyle)
-                    task.with {
-                        description = "Run Checkstyle analysis for ${sourceSet.name} classes"
-                        source = sourceSet.java.srcDirs
-                        classpath = files("$buildDir/intermediates/classes/")
-                        exclude '**/*.kt'
-                    }
-                }
+        variant.sourceSets.each { sourceSet ->
+            def taskName = "checkstyle${sourceSet.name.capitalize()}"
+
+            maybeCreateTask(project, taskName, Checkstyle) { Checkstyle task ->
+                task.description = "Run Checkstyle analysis for ${sourceSet.name} classes"
+                task.source = sourceSet.java.srcDirs
+                task.classpath = project.files("$project.buildDir/intermediates/classes/")
+                task.exclude '**/*.kt'
                 sourceFilter.applyTo(task)
                 task.mustRunAfter variant.javaCompile
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -6,7 +6,6 @@ import com.novoda.staticanalysis.internal.QuietLogger
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension
 
@@ -14,17 +13,13 @@ import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
 
 class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, CheckstyleExtension> {
 
-    static CheckstyleConfigurator create(Project project,
-                                         NamedDomainObjectContainer<Violations> violationsContainer,
-                                         Task evaluateViolations) {
+    static CheckstyleConfigurator create(Project project, NamedDomainObjectContainer<Violations> violationsContainer) {
         Violations violations = violationsContainer.maybeCreate('Checkstyle')
-        return new CheckstyleConfigurator(project, violations, evaluateViolations)
+        return new CheckstyleConfigurator(project, violations)
     }
 
-    private CheckstyleConfigurator(Project project,
-                                   Violations violations,
-                                   Task evaluateViolations) {
-        super(project, violations, evaluateViolations)
+    private CheckstyleConfigurator(Project project, Violations violations) {
+        super(project, violations)
     }
 
     @Override
@@ -71,8 +66,7 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
         checkstyle.ignoreFailures = true
         checkstyle.metaClass.getLogger = { QuietLogger.INSTANCE }
 
-        def collectViolations = createCollectViolationsTask(checkstyle, violations)
-        evaluateViolations.dependsOn collectViolations
+        createCollectViolationsTask(checkstyle, violations)
     }
 
     private def createCollectViolationsTask(Checkstyle checkstyle, Violations violations) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -10,6 +10,8 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstyleExtension
 
+import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
+
 class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, CheckstyleExtension> {
 
     static CheckstyleConfigurator create(Project project,
@@ -75,15 +77,14 @@ class CheckstyleConfigurator extends CodeQualityConfigurator<Checkstyle, Checkst
         checkstyle.metaClass.getLogger = { QuietLogger.INSTANCE }
 
         def collectViolations = createCollectViolationsTask(checkstyle, violations)
-
         evaluateViolations.dependsOn collectViolations
-        collectViolations.dependsOn checkstyle
     }
 
-    private CollectCheckstyleViolationsTask createCollectViolationsTask(Checkstyle checkstyle, Violations violations) {
-        def task = project.tasks.maybeCreate("collect${checkstyle.name.capitalize()}Violations", CollectCheckstyleViolationsTask)
-        task.xmlReportFile = checkstyle.reports.xml.destination
-        task.violations = violations
-        task
+    private def createCollectViolationsTask(Checkstyle checkstyle, Violations violations) {
+        maybeCreateTask(project, "collect${checkstyle.name.capitalize()}Violations", CollectCheckstyleViolationsTask) { task ->
+            task.xmlReportFile = checkstyle.reports.xml.destination
+            task.violations = violations
+            task.dependsOn(checkstyle)
+        }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -9,6 +9,8 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 
+import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
+
 class DetektConfigurator implements Configurator {
 
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
@@ -21,7 +23,6 @@ class DetektConfigurator implements Configurator {
     private final Project project
     private final Violations violations
     private final Task evaluateViolations
-
 
     static DetektConfigurator create(Project project,
                                      NamedDomainObjectContainer<Violations> violationsContainer,
@@ -47,7 +48,7 @@ class DetektConfigurator implements Configurator {
                 throw new GradleException(DETEKT_NOT_APPLIED)
             }
 
-            def detekt = project.extensions.findByName('detekt')
+            def detekt = project.extensions['detekt']
             setDefaultXmlReport(detekt)
             config.delegate = detekt
             config()
@@ -66,7 +67,7 @@ class DetektConfigurator implements Configurator {
         }
     }
 
-    private CollectCheckstyleViolationsTask configureToolTask(detekt) {
+    private def configureToolTask(detekt) {
         def detektTask = project.tasks.findByName('detekt')
         if (detektTask?.hasProperty('reports')) {
             def reports = detektTask.reports
@@ -105,12 +106,11 @@ class DetektConfigurator implements Configurator {
         }
     }
 
-    private CollectCheckstyleViolationsTask createCollectViolationsTask(Violations violations, detektTask, File xmlReportFile, File htmlReportFile) {
-        project.tasks.create('collectDetektViolations', CollectCheckstyleViolationsTask) { task ->
+    private def createCollectViolationsTask(Violations violations, detektTask, File xmlReportFile, File htmlReportFile) {
+        maybeCreateTask(project, 'collectDetektViolations', CollectCheckstyleViolationsTask) { task ->
             task.xmlReportFile = xmlReportFile
             task.htmlReportFile = htmlReportFile
             task.violations = violations
-
             task.dependsOn(detektTask)
         }
     }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -7,7 +7,6 @@ import com.novoda.staticanalysis.internal.checkstyle.CollectCheckstyleViolations
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
 
@@ -22,19 +21,15 @@ class DetektConfigurator implements Configurator {
 
     private final Project project
     private final Violations violations
-    private final Task evaluateViolations
 
-    static DetektConfigurator create(Project project,
-                                     NamedDomainObjectContainer<Violations> violationsContainer,
-                                     Task evaluateViolations) {
+    static DetektConfigurator create(Project project, NamedDomainObjectContainer<Violations> violationsContainer) {
         Violations violations = violationsContainer.maybeCreate('Detekt')
-        return new DetektConfigurator(project, violations, evaluateViolations)
+        return new DetektConfigurator(project, violations)
     }
 
-    private DetektConfigurator(Project project, Violations violations, Task evaluateViolations) {
+    private DetektConfigurator(Project project, Violations violations) {
         this.project = project
         this.violations = violations
-        this.evaluateViolations = evaluateViolations
     }
 
     @Override
@@ -53,8 +48,7 @@ class DetektConfigurator implements Configurator {
             config.delegate = detekt
             config()
 
-            def collectViolations = configureToolTask(detekt)
-            evaluateViolations.dependsOn collectViolations
+            configureToolTask(detekt)
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -5,7 +5,6 @@ import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.quality.FindBugs
@@ -18,17 +17,13 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     protected boolean htmlReportEnabled = true
 
-    static FindbugsConfigurator create(Project project,
-                                       NamedDomainObjectContainer<Violations> violationsContainer,
-                                       Task evaluateViolations) {
+    static FindbugsConfigurator create(Project project, NamedDomainObjectContainer<Violations> violationsContainer) {
         Violations violations = violationsContainer.maybeCreate('Findbugs')
-        return new FindbugsConfigurator(project, violations, evaluateViolations)
+        return new FindbugsConfigurator(project, violations)
     }
 
-    private FindbugsConfigurator(Project project,
-                                 Violations violations,
-                                 Task evaluateViolations) {
-        super(project, violations, evaluateViolations)
+    private FindbugsConfigurator(Project project, Violations violations) {
+        super(project, violations)
     }
 
     @Override
@@ -138,7 +133,6 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         findBugs.reports.html.enabled = false
 
         def collectViolations = createViolationsCollectionTask(findBugs, violations)
-        evaluateViolations.dependsOn collectViolations
 
         if (htmlReportEnabled) {
             def generateHtmlReport = createHtmlReportTask(findBugs, collectViolations.xmlReportFile, collectViolations.htmlReportFile)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/lint/LintConfigurator.groovy
@@ -7,7 +7,6 @@ import com.novoda.staticanalysis.internal.VariantFilter
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
 
@@ -15,20 +14,16 @@ class LintConfigurator implements Configurator {
 
     private final Project project
     private final Violations violations
-    private final Task evaluateViolations
     private final VariantFilter variantFilter
 
-    static LintConfigurator create(Project project,
-                                   NamedDomainObjectContainer<Violations> violationsContainer,
-                                   Task evaluateViolations) {
+    static LintConfigurator create(Project project, NamedDomainObjectContainer<Violations> violationsContainer) {
         Violations violations = violationsContainer.maybeCreate('Lint')
-        return new LintConfigurator(project, violations, evaluateViolations)
+        return new LintConfigurator(project, violations)
     }
 
-    private LintConfigurator(Project project, Violations violations, Task evaluateViolations) {
+    private LintConfigurator(Project project, Violations violations) {
         this.project = project
         this.violations = violations
-        this.evaluateViolations = evaluateViolations
         this.variantFilter = new VariantFilter(project)
     }
 
@@ -69,11 +64,6 @@ class LintConfigurator implements Configurator {
     }
 
     private void configureCollectViolationsTask(String taskSuffix = '', String reportFileName) {
-        def collectViolations = createCollectViolationsTask(taskSuffix, reportFileName, violations)
-        evaluateViolations.dependsOn collectViolations
-    }
-
-    private def createCollectViolationsTask(String taskSuffix, String reportFileName, Violations violations) {
         maybeCreateTask(project, "collectLint${taskSuffix.capitalize()}Violations", CollectLintViolationsTask) { task ->
             task.xmlReportFile = xmlOutputFileFor(reportFileName)
             task.htmlReportFile = htmlOutputFileFor(reportFileName)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -6,7 +6,6 @@ import com.novoda.staticanalysis.internal.QuietLogger
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
 
@@ -14,17 +13,13 @@ import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
 
 class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
-    static PmdConfigurator create(Project project,
-                                  NamedDomainObjectContainer<Violations> violationsContainer,
-                                  Task evaluateViolations) {
+    static PmdConfigurator create(Project project, NamedDomainObjectContainer<Violations> violationsContainer) {
         Violations violations = violationsContainer.maybeCreate('PMD')
-        return new PmdConfigurator(project, violations, evaluateViolations)
+        return new PmdConfigurator(project, violations)
     }
 
-    private PmdConfigurator(Project project,
-                            Violations violations,
-                            Task evaluateViolations) {
-        super(project, violations, evaluateViolations)
+    private PmdConfigurator(Project project, Violations violations) {
+        super(project, violations)
     }
 
     @Override
@@ -69,8 +64,7 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
         pmd.ignoreFailures = true
         pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
 
-        def collectViolations = createViolationsCollectionTask(pmd, violations)
-        evaluateViolations.dependsOn collectViolations
+        createViolationsCollectionTask(pmd, violations)
     }
 
     private def createViolationsCollectionTask(Pmd pmd, Violations violations) {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -52,18 +52,12 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
     @Override
     protected void configureAndroidVariant(variant) {
-        project.with {
-            variant.sourceSets.each { sourceSet ->
-                def taskName = "pmd${sourceSet.name.capitalize()}"
-                Pmd task = tasks.findByName(taskName)
-                if (task == null) {
-                    task = tasks.create(taskName, Pmd)
-                    task.with {
-                        description = "Run PMD analysis for ${sourceSet.name} classes"
-                        source = sourceSet.java.srcDirs
-                        exclude '**/*.kt'
-                    }
-                }
+        variant.sourceSets.each { sourceSet ->
+            def taskName = "pmd${sourceSet.name.capitalize()}"
+            maybeCreateTask(project, taskName, Pmd) { Pmd task ->
+                task.description = "Run PMD analysis for ${sourceSet.name} classes"
+                task.source = sourceSet.java.srcDirs
+                task.exclude '**/*.kt'
                 sourceFilter.applyTo(task)
                 task.mustRunAfter variant.javaCompile
             }

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -10,6 +10,8 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.plugins.quality.PmdExtension
 
+import static com.novoda.staticanalysis.internal.TasksCompat.maybeCreateTask
+
 class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
 
     static PmdConfigurator create(Project project,
@@ -74,16 +76,14 @@ class PmdConfigurator extends CodeQualityConfigurator<Pmd, PmdExtension> {
         pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
 
         def collectViolations = createViolationsCollectionTask(pmd, violations)
-
         evaluateViolations.dependsOn collectViolations
-        collectViolations.dependsOn pmd
     }
 
-    private CollectPmdViolationsTask createViolationsCollectionTask(Pmd pmd, Violations violations) {
-        def task = project.tasks.maybeCreate("collect${pmd.name.capitalize()}Violations", CollectPmdViolationsTask)
-        task.xmlReportFile = pmd.reports.xml.destination
-        task.violations = violations
-        task
+    private def createViolationsCollectionTask(Pmd pmd, Violations violations) {
+        maybeCreateTask(project, "collect${pmd.name.capitalize()}Violations", CollectPmdViolationsTask) { task ->
+            task.xmlReportFile = pmd.reports.xml.destination
+            task.violations = violations
+            task.dependsOn(pmd)
+        }
     }
-
 }


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

This is a feature that became stable in Gradle 5.1 but the APIs were introduced in Gradle 4.9

This allows lazy configuration of tasks. Android Tools already migrated in 3.3 and 3.4 and saved configuration of thousands of tasks. Unfortunately our plugin resolves those tasks. Since they are the entry points of the whole system, that transitively configures thousands more. 

This is a WIP that allows nothing to be configured unless `evaluateViolations` is run.

Running `evaluateViolations` explicitly will have 0 behavior change. This is how the plugin is supposed to be used, so it is no problem. But still I think I need to explain the rest. When `evaluateViolations` is not run, task dependencies are not necessarily set since they are lazy and may not be run/configured. Some of the `collect${toolName}Violations` tasks may not even be available anymore unless `evaluateViolations` is run.

**Disclamier:** Currently opened the PR for pre-review and testing with CI.

I need to do more intensive manual testing to make sure we don't configure any task eagerly.