### PR TITLE
Change deprecated classesDir for classesDirs

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -126,7 +126,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
      * being passed to FindBugs Ant task, resulting in an error
      * */
     private ConfigurableFileTree createClassesTreeFrom(SourceSet sourceSet) {
-        project.fileTree(sourceSet.output.classesDir, {
+        project.fileTree(sourceSet.output.classesDirs, {
             it.builtBy(sourceSet.output)
         })
     }


### PR DESCRIPTION
`classesDir` is deprecated in Gradle 4.x and we should use `classesDirs` instead as Gradle 5.x removes this property.

Without this change, Gradle complains about it if we use Gradle 5.x on the client:
```
* What went wrong:
Could not determine the dependencies of task ':core-java:findbugsMain'.
> Could not get unknown property 'classesDir' for main classes of type org.gradle.api.internal.tasks.DefaultSourceSetOutput.

```

Fixes #94