### PR TITLE
Fix missing `builtBy()` using Gradle 5

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -122,11 +122,10 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     private ConfigurableFileTree createClassesTreeFrom(SourceSet sourceSet) {
-        def fileTree = sourceSet.output.classesDirs.inject(null) { cumulativeTree, classesDir ->
-            def tree = project.fileTree(classesDir)
+        return sourceSet.output.classesDirs.inject(null) { cumulativeTree, classesDir ->
+            def tree = project.fileTree(classesDir).builtBy(sourceSet.output)
             cumulativeTree?.plus(tree) ?: tree
         }
-        fileTree.builtBy(sourceSet.output)
     }
 
     @Override


### PR DESCRIPTION
### Problem

I quickly tried to apply `SNAPSHOT-43` to an existing project using Gradle 5.x and I experienced the following error:
```
> No signature of method: org.gradle.api.internal.file.UnionFileTree.builtBy() is applicable for argument types: (org.gradle.api.internal.tasks.DefaultSourceSetOutput_Decorated) values: [main classes]
  Possible solutions: filter(groovy.lang.Closure), filter(org.gradle.api.specs.Spec), filter(org.gradle.api.specs.Spec), countBy(groovy.lang.Closure)
```

### Solution

The tree used to accumulate the content of each dir in `classesDirs` using `plus()` is of type `UnionFileTree`, so does not contain `builtBy()` (while `ConfigurableTree` does). The simplest solution is to apply `builtBy` to each subtree instead of the cumulative one.