### PR TITLE
Prepare release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+[Version 0.8.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.8.1)
+--------------------------
+
+- Removed use of `classesDir` because deprecated in Gradle 5.x ([PR#174](https://github.com/novoda/gradle-static-analysis-plugin/pull/174),
+[PR#178](https://github.com/novoda/gradle-static-analysis-plugin/pull/178),
+[PR#179](https://github.com/novoda/gradle-static-analysis-plugin/pull/179),
+[PR#180](https://github.com/novoda/gradle-static-analysis-plugin/pull/180))
+- Included new versions of Ktlint in functional tests ([PR#167](https://github.com/novoda/gradle-static-analysis-plugin/pull/167))
+- Added automatic tagging of snapshot releases ([PR#176](https://github.com/novoda/gradle-static-analysis-plugin/pull/176))
+
+
 [Version 0.8](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.8)
 --------------------------
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,7 +2,7 @@ ext {
     websiteUrl = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 
-version = '0.8'
+version = '0.8.1'
 groovydoc.docTitle = 'Static Analysis Plugin'
 
 apply plugin: 'com.novoda.build-properties'


### PR DESCRIPTION
## Scope of the PR

We want to release a new version of the plugin with all the changes already available in [`SNAPSHOT-45`](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/SNAPSHOT-45)  (including #167, #174, #176, #178, #179, #180)

## Considerations and implementation
- Updated `CHANGELOG`
- Bumped version for release
