### PR TITLE
Remove afterEvaluate together with support for older versions of Ktlint plugin

### DIFF
--- a/docs/tools/ktlint.md
+++ b/docs/tools/ktlint.md
@@ -2,6 +2,8 @@
 [Ktlint](https://github.com/shyiko/ktlint) is a linter for Kotlin with a built-in formatter. It does not support Java. Adding 
 this tool only makes sense when you have Kotlin sources in your project. 
 
+> Supported Ktlint Gradle Plugin version: **6.0.0 and above** 
+
 ## Table of contents
  * [IMPORTANT: setup Ktlint](#important-setup-ktlint)
  * [Configure Ktlint](#configure-ktlint)
@@ -24,7 +26,7 @@ In most common cases, adding Ktlint to a project boils down to these simple step
  1. Add this statement to your root `build.gradle` project (change the version according to your needs):
     ```gradle
     plugins {
-        id 'org.jlleitschuh.gradle.ktlint' version '5.1.0'
+        id 'org.jlleitschuh.gradle.ktlint' version '7.3.0'
         // ...
     }
     ```

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -45,26 +45,23 @@ class KtlintConfigurator implements Configurator {
 
             configureKtlintExtension(config)
 
-            project.afterEvaluate {
-
-                project.plugins.withId("kotlin") {
-                    configureKotlinProject()
-                }
-                project.plugins.withId("kotlin2js") {
-                    configureKotlinProject()
-                }
-                project.plugins.withId("kotlin-platform-common") {
-                    configureKotlinProject()
-                }
-                project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
-                    configureKotlinProject()
-                }
-                project.plugins.withId('com.android.application') {
-                    configureAndroidWithVariants(variantFilter.filteredApplicationVariants)
-                }
-                project.plugins.withId('com.android.library') {
-                    configureAndroidWithVariants(variantFilter.filteredLibraryVariants)
-                }
+            project.plugins.withId("kotlin") {
+                configureKotlinProject()
+            }
+            project.plugins.withId("kotlin2js") {
+                configureKotlinProject()
+            }
+            project.plugins.withId("kotlin-platform-common") {
+                configureKotlinProject()
+            }
+            project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
+                configureKotlinProject()
+            }
+            project.plugins.withId('com.android.application') {
+                configureAndroidWithVariants(variantFilter.filteredApplicationVariants)
+            }
+            project.plugins.withId('com.android.library') {
+                configureAndroidWithVariants(variantFilter.filteredLibraryVariants)
             }
         }
     }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -30,10 +30,6 @@ class KtlintIntegrationTest {
     @Parameterized.Parameters(name = '{0} with ktlint {1}')
     static def rules() {
         return [
-                [TestProjectRule.forKotlinProject(), '4.1.0', 'ktlint-main.txt'],
-                [TestProjectRule.forAndroidKotlinProject(), '4.1.0', 'ktlint-debug.txt'],
-                [TestProjectRule.forKotlinProject(), '5.1.0', 'ktlint-main.txt'],
-                [TestProjectRule.forAndroidKotlinProject(), '5.1.0', 'ktlint-debug.txt'],
                 [TestProjectRule.forKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
@@ -42,6 +38,8 @@ class KtlintIntegrationTest {
                 [TestProjectRule.forAndroidKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '7.0.0', 'ktlintMainSourceSetCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '7.0.0', 'ktlintMainSourceSetCheck.txt'],
+                [TestProjectRule.forKotlinProject(), '7.3.0', 'ktlintMainSourceSetCheck.txt'],
+                [TestProjectRule.forAndroidKotlinProject(), '7.3.0', 'ktlintMainSourceSetCheck.txt'],
         ]*.toArray()
     }
 


### PR DESCRIPTION
`afterEvaluate` usage is not good since it requires the clients to use `afterEvaluate` in certain conditions. 

This was required initially because ktlint plugin itself was using it. That is fixed quite a while ago. 

## Solution: 

- Remove `afterEvaluate`
- Remove older version support for ktlint
- Update the docs to indicate that we support version 6 and above

Fixes #156 