### PR TITLE
Bug fix: define closure strategy

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/CodeQualityConfigurator.groovy
@@ -34,6 +34,7 @@ abstract class CodeQualityConfigurator<T extends SourceTask, E extends CodeQuali
                 ext.exclude = { Object rule -> sourceFilter.exclude(rule) }
                 ext.includeVariants = { Closure<Boolean> filter -> variantFilter.includeVariantsFilter = filter }
                 config.delegate = it
+                config.resolveStrategy = Closure.DELEGATE_FIRST
                 config()
             }
             project.plugins.withId('com.android.application') {

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -50,6 +50,7 @@ class DetektConfigurator implements Configurator {
             def detekt = project.extensions.findByName('detekt')
             setDefaultXmlReport(detekt)
             config.delegate = detekt
+            config.resolveStrategy = Closure.DELEGATE_FIRST
             config()
 
             def collectViolations = configureToolTask(detekt)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -73,6 +73,7 @@ class KtlintConfigurator implements Configurator {
             variantFilter.includeVariantsFilter = filter
         }
         config.delegate = ktlint
+        config.resolveStrategy = Closure.DELEGATE_FIRST
         config()
     }
 


### PR DESCRIPTION
# Problem

We are using very powerful feature of Closure in Groovy which is to define delegates. I've realized that some properties were just not working if they clash with something that is already defined in my script.

If it is a function call, it would call the function I defined instead of the one in the tool.

# Solution

I've researched and learned that Closure's prefer the Owner over the Delegate first. But by providing custom strategy, we can force to use only the delegate. 

In this case, the delegate is the static analysis tool we are integrating.