### PR TITLE
Small fix - check task not found on empty project

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,6 +1,6 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.internal.CodeQualityConfigurator
+import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
 import com.novoda.staticanalysis.internal.detekt.DetektConfigurator
 import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator
@@ -20,7 +20,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
         def evaluateViolations = createEvaluateViolationsTask(project, pluginExtension)
         createConfigurators(project, pluginExtension, evaluateViolations).each { configurator -> configurator.execute() }
         project.afterEvaluate {
-            project.tasks['check'].dependsOn evaluateViolations
+            project.tasks.findByName('check')?.dependsOn evaluateViolations
         }
     }
 
@@ -32,9 +32,9 @@ class StaticAnalysisPlugin implements Plugin<Project> {
         }
     }
 
-    private static List<CodeQualityConfigurator> createConfigurators(Project project,
-                                                                     StaticAnalysisExtension pluginExtension,
-                                                                     Task evaluateViolations) {
+    private static List<Configurator> createConfigurators(Project project,
+                                                          StaticAnalysisExtension pluginExtension,
+                                                          Task evaluateViolations) {
         NamedDomainObjectContainer<Violations> violationsContainer = pluginExtension.allViolations
         [
                 CheckstyleConfigurator.create(project, violationsContainer, evaluateViolations),

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/StaticAnalysisPluginTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/StaticAnalysisPluginTest.groovy
@@ -1,0 +1,35 @@
+package com.novoda.staticanalysis
+
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+
+class StaticAnalysisPluginTest {
+
+    @Rule
+    public final TestProjectRule rule = new TestProjectRule({ new EmptyProject() }, { "" }, 'Empty project')
+
+    @Test
+    void shouldNotFailWhenNoJavaOrAndroidPluginsAreApplied() {
+        rule.newProject()
+                .build("help")
+    }
+
+    private static class EmptyProject extends TestProject<EmptyProject> {
+        private static final Closure<String> TEMPLATE = { TestProject project ->
+            """
+buildscript {
+    dependencies {
+        classpath 'com.novoda:gradle-static-analysis-plugin:local'
+    }
+}
+apply plugin: 'com.novoda.static-analysis'
+"""
+        }
+
+        EmptyProject() {
+            super(TEMPLATE)
+        }
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestProjectRule.groovy
@@ -27,7 +27,7 @@ final class TestProjectRule<T extends TestProject> implements TestRule {
         new TestProjectRule({ new TestKotlinProject() }, { String name -> "project.sourceSets.$name" }, 'Kotlin project')
     }
 
-    private TestProjectRule(Closure projectFactory, Closure sourceSetNameFactory, String label) {
+    TestProjectRule(Closure projectFactory, Closure sourceSetNameFactory, String label) {
         this.projectFactory = projectFactory
         this.sourceSetNameFactory = sourceSetNameFactory
         this.label = label


### PR DESCRIPTION
SAP automatically configures itself when it detects other tools and project setup.

When nothing is setup, (except for resolving `check` task), the plugin is no-op.

Right now, resolving `check` would break on an empty project with unclear error.

This PR fixes that and make setting up check task optional

Wrote a failing test first 👇 
![Screen Shot 2019-05-10 at 23 21 49](https://user-images.githubusercontent.com/763339/57557709-5d992500-737b-11e9-8afd-0138017cded8.png)
