### PR TITLE
Lazy Task Configuration for ktlint

### DIFF
--- a/docs/tools/ktlint.md
+++ b/docs/tools/ktlint.md
@@ -2,7 +2,7 @@
 [Ktlint](https://github.com/shyiko/ktlint) is a linter for Kotlin with a built-in formatter. It does not support Java. Adding 
 this tool only makes sense when you have Kotlin sources in your project. 
 
-> Supported Ktlint Gradle Plugin version: **6.0.0 and above** 
+> Supported Ktlint Gradle Plugin version: **6.2.1 and above** 
 
 ## Table of contents
  * [IMPORTANT: setup Ktlint](#important-setup-ktlint)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Exceptions.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Exceptions.groovy
@@ -1,0 +1,17 @@
+package com.novoda.staticanalysis.internal
+
+import org.gradle.api.GradleException
+
+class Exceptions {
+
+    /**
+     * In case the cause is a GradleException rethrow because it probably already has useful information.
+     * If not, wrap it and put useful information about the state of the integrations and versions.
+     */
+    static void handleException(String message, Exception cause) {
+        if (cause instanceof GradleException) {
+            throw cause
+        }
+        throw new GradleException(message, cause)
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -15,10 +15,11 @@ import static com.novoda.staticanalysis.internal.TasksCompat.createTask
 class DetektConfigurator implements Configurator {
 
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
-    private static final String LAST_COMPATIBLE_DETEKT_VERSION = '1.0.0-RC14'
-    private static final String MIN_COMPATIBLE_DETEKT_VERSION = '1.0.0.RC9.2'
     private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
     private static final String XML_REPORT_NOT_ENABLED = 'XML report must be enabled. Please make sure to enable "reports.xml" in your Detekt configuration'
+
+    private static final String LAST_COMPATIBLE_DETEKT_VERSION = '1.0.0-RC14'
+    private static final String MIN_COMPATIBLE_DETEKT_VERSION = '1.0.0.RC9.2' // Do not forget to update detekt.md
     private static final String DETEKT_CONFIGURATION_ERROR = """\
 A problem occurred while configuring Detekt. Please make sure to use a compatible version:
 Minimum compatible Detekt version: $MIN_COMPATIBLE_DETEKT_VERSION

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -9,15 +9,21 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 
+import static com.novoda.staticanalysis.internal.Exceptions.handleException
 import static com.novoda.staticanalysis.internal.TasksCompat.createTask
 
 class DetektConfigurator implements Configurator {
 
     private static final String DETEKT_PLUGIN = 'io.gitlab.arturbosch.detekt'
     private static final String LAST_COMPATIBLE_DETEKT_VERSION = '1.0.0-RC14'
+    private static final String MIN_COMPATIBLE_DETEKT_VERSION = '1.0.0.RC9.2'
     private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
-    private static final String DETEKT_CONFIGURATION_ERROR = "A problem occurred while configuring Detekt. Please make sure to use a compatible version (All versions up to $LAST_COMPATIBLE_DETEKT_VERSION)"
     private static final String XML_REPORT_NOT_ENABLED = 'XML report must be enabled. Please make sure to enable "reports.xml" in your Detekt configuration'
+    private static final String DETEKT_CONFIGURATION_ERROR = """\
+A problem occurred while configuring Detekt. Please make sure to use a compatible version:
+Minimum compatible Detekt version: $MIN_COMPATIBLE_DETEKT_VERSION
+Last tested compatible version: $LAST_COMPATIBLE_DETEKT_VERSION
+"""
 
     private final Project project
     private final Violations violations
@@ -66,7 +72,7 @@ class DetektConfigurator implements Configurator {
                 xml.destination = new File(project.buildDir, 'reports/detekt/detekt.xml')
             }
         } catch (Exception exception) {
-            throw new GradleException(DETEKT_CONFIGURATION_ERROR, exception)
+            handleException(DETEKT_CONFIGURATION_ERROR, exception)
         }
     }
 
@@ -85,7 +91,7 @@ class DetektConfigurator implements Configurator {
                 task.xmlReportFile = reports.xml.destination
                 task.htmlReportFile = reports.html.destination
             } catch (Exception exception) {
-                throw new GradleException(DETEKT_CONFIGURATION_ERROR, exception)
+                handleException(DETEKT_CONFIGURATION_ERROR, exception)
             }
             task.violations = violations
             task.dependsOn detektTask
@@ -94,7 +100,7 @@ class DetektConfigurator implements Configurator {
 
     private void checkXmlReportEnabled(reports) {
         if (!reports.xml.enabled) {
-            throw new IllegalStateException(XML_REPORT_NOT_ENABLED)
+            throw new GradleException(XML_REPORT_NOT_ENABLED)
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -20,7 +20,7 @@ class KtlintConfigurator implements Configurator {
     private static final String XML_REPORT_NOT_ENABLED = 'XML report must be enabled. Please make sure to add "CHECKSTYLE" into reports in your Ktlint configuration'
 
     private static final String LAST_COMPATIBLE_KTLINT_VERSION = '8.0.0'
-    private static final String MIN_COMPATIBLE_KTLINT_VERSION = '6.2.1'
+    private static final String MIN_COMPATIBLE_KTLINT_VERSION = '6.2.1' // Do not forget to update ktlint.md
     private static final String KTLINT_CONFIGURATION_ERROR = """\
 A problem occurred while configuring Ktlint. Please make sure to use a compatible version:
 Minimum compatible Ktlint Plugin version: $MIN_COMPATIBLE_KTLINT_VERSION

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintConfigurator.groovy
@@ -3,6 +3,7 @@ package com.novoda.staticanalysis.internal.ktlint
 import com.novoda.staticanalysis.StaticAnalysisExtension
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.Configurator
+import com.novoda.staticanalysis.internal.TasksCompat
 import com.novoda.staticanalysis.internal.VariantFilter
 import com.novoda.staticanalysis.internal.checkstyle.CollectCheckstyleViolationsTask
 import org.gradle.api.GradleException
@@ -10,6 +11,8 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.RegularFileProperty
+
+import static com.novoda.staticanalysis.internal.TasksCompat.createTask
 
 class KtlintConfigurator implements Configurator {
 
@@ -21,6 +24,7 @@ class KtlintConfigurator implements Configurator {
     private final Violations violations
     private final Task evaluateViolations
     private final VariantFilter variantFilter
+    protected boolean configured = false
 
     static KtlintConfigurator create(Project project,
                                      NamedDomainObjectContainer<Violations> violationsContainer,
@@ -78,64 +82,63 @@ class KtlintConfigurator implements Configurator {
     }
 
     private void configureKotlinProject() {
-        project.sourceSets.each { configureKtlint(it.name) }
-    }
-
-    private void configureAndroidWithVariants(def mainVariants) {
-        mainVariants.all { configureAndroidVariant(it) }
-        variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
-        variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
-    }
-
-    private void configureAndroidVariant(def variant) {
-        variant.sourceSets.each { sourceSet ->
-            configureKtlint(sourceSet.name)
-        }
-    }
-
-    private void configureKtlint(String sourceSetName) {
-        project.tasks.matching {
-            isKtlintTask(it, sourceSetName.capitalize())
-        }.all { Task ktlintTask ->
-            def collectViolations = configureKtlintWithOutputFiles(sourceSetName, ktlintTask.reportOutputFiles)
-            collectViolations.dependsOn ktlintTask
+        project.sourceSets.each {
+            def collectViolations = createCollectViolationsTask(violations, it.name)
             evaluateViolations.dependsOn collectViolations
         }
     }
 
-    /**
-     * KtLint task has the following naming convention and the needed property to resolve the reportOutputFiles
-     */
-    private boolean isKtlintTask(Task task, String sourceSetName) {
-        task.name ==~ /^ktlint$sourceSetName(SourceSet)?Check$/ && task.hasProperty('reportOutputFiles')
+    private void configureAndroidWithVariants(def mainVariants) {
+        if (configured) return
+
+        project.android.sourceSets.all { sourceSet ->
+            createCollectViolationsTask(violations, sourceSet.name)
+        }
+        mainVariants.all { configureAndroidVariant(it) }
+        variantFilter.filteredTestVariants.all { configureAndroidVariant(it) }
+        variantFilter.filteredUnitTestVariants.all { configureAndroidVariant(it) }
+        configured = true
     }
 
-    private def configureKtlintWithOutputFiles(String sourceSetName, Map<?, RegularFileProperty> reportOutputFiles) {
-        File xmlReportFile = null
-        File txtReportFile = null
-        reportOutputFiles.each { key, fileProp ->
-            def file = fileProp.get().asFile
-            if (file.name.endsWith('.xml')) {
-                xmlReportFile = file
-            }
-            if (file.name.endsWith('.txt')) {
-                txtReportFile = file
-            }
-        }
-
-        if (xmlReportFile == null) {
-            throw new IllegalStateException(XML_REPORT_NOT_ENABLED)
-        }
-
-        createCollectViolationsTask(violations, sourceSetName, xmlReportFile, txtReportFile)
+    private void configureAndroidVariant(def variant) {
+        def collectViolations = createVariantMetaTask(variant)
+        evaluateViolations.dependsOn collectViolations
     }
 
-    private def createCollectViolationsTask(Violations violations, def sourceSetName, File xmlReportFile, File txtReportFile) {
-        CollectCheckstyleViolationsTask task =
-                project.tasks.maybeCreate("collectKtlint${sourceSetName.capitalize()}Violations", CollectCheckstyleViolationsTask)
-        task.xmlReportFile = xmlReportFile
-        task.htmlReportFile = txtReportFile
-        task.violations = violations
-        return task
+    private def createVariantMetaTask(variant) {
+        createTask(project, "collectKtlint${variant.name.capitalize()}VariantViolations", Task) { task ->
+            variant.sourceSets.forEach { sourceSet ->
+                task.dependsOn "collectKtlint${sourceSet.name.capitalize()}Violations"
+            }
+        }
+    }
+
+    private def createCollectViolationsTask(Violations violations, def sourceSetName) {
+        createTask(project, "collectKtlint${sourceSetName.capitalize()}Violations", CollectCheckstyleViolationsTask) { task ->
+            Task ktlintTask = project.tasks.findByName("ktlint${sourceSetName.capitalize()}SourceSetCheck")
+            if (ktlintTask == null) {
+                ktlintTask = project.tasks.findByName("ktlint${sourceSetName.capitalize()}Check")
+            }
+
+            File xmlReportFile = null
+            File txtReportFile = null
+            ktlintTask.reportOutputFiles.each { key, fileProp ->
+                def file = fileProp.get().asFile
+                if (file.name.endsWith('.xml')) {
+                    xmlReportFile = file
+                }
+                if (file.name.endsWith('.txt')) {
+                    txtReportFile = file
+                }
+            }
+
+            if (xmlReportFile == null) {
+                throw new IllegalStateException(XML_REPORT_NOT_ENABLED)
+            }
+            task.xmlReportFile = xmlReportFile
+            task.htmlReportFile = txtReportFile
+            task.violations = violations
+            task.dependsOn ktlintTask
+        }
     }
 }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/ktlint/KtlintIntegrationTest.groovy
@@ -30,16 +30,19 @@ class KtlintIntegrationTest {
     @Parameterized.Parameters(name = '{0} with ktlint {1}')
     static def rules() {
         return [
-                [TestProjectRule.forKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
-                [TestProjectRule.forAndroidKotlinProject(), '6.1.0', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '6.2.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '6.3.1', 'ktlintMainCheck.txt'],
-                [TestProjectRule.forKotlinProject(), '7.0.0', 'ktlintMainSourceSetCheck.txt'],
+                // Fails because of Android dependency problem in non-Android project.
+                // > Could not generate a decorated class for class org.jlleitschuh.gradle.ktlint.KtlintPlugin.
+                //         > com/android/build/gradle/BaseExtension
+                // [TestProjectRule.forKotlinProject(), '7.0.0', 'ktlintMainSourceSetCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '7.0.0', 'ktlintMainSourceSetCheck.txt'],
                 [TestProjectRule.forKotlinProject(), '7.3.0', 'ktlintMainSourceSetCheck.txt'],
                 [TestProjectRule.forAndroidKotlinProject(), '7.3.0', 'ktlintMainSourceSetCheck.txt'],
+                [TestProjectRule.forKotlinProject(), '8.0.0', 'ktlintMainSourceSetCheck.txt'],
+                [TestProjectRule.forAndroidKotlinProject(), '8.0.0', 'ktlintMainSourceSetCheck.txt'],
         ]*.toArray()
     }
 


### PR DESCRIPTION
This is the last PR of the series where I enable lazy task configuration. Fixes #161 

We had somewhat complex (but well tested) setup for ktlint where we support multiple versions even-though there were breaking changes in between. To be able to do this, I used `matching` to dynamically load all Ktlint tasks and pick the ones that we are interested in. This of course resolve tasks and breaks task configuration avoidance. 

In order to handle this, we need to know more about how Ktlint tasks are created. With the latest versions, they are created per source set which is pretty consistent with other tools configurations we have 

This is why support for version 6.1 is removed.

### Additionally 

Also added try-catch for any future exceptions with a clear output of the current state with clear message of which versions of Ktlint and Detekt we support.

### Final screenshot: 

All tools enabled from `sample` and majority of the tasks are avoided 

![image](https://user-images.githubusercontent.com/763339/57891823-1a3c2c00-783d-11e9-8749-474975709cc6.png)
