### PR TITLE
Prepare release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Change Log
 ==========
 
+[Version 1.0](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v1.0)
+--------------------------
+                      
+- Add support for task configuration avoidance [PR#184](https://github.com/novoda/gradle-static-analysis-plugin/pull/184) [PR#186](https://github.com/novoda/gradle-static-analysis-plugin/pull/186) [PR#189](https://github.com/novoda/gradle-static-analysis-plugin/pull/189)
+  - This is a big performance improvement and a recommended upgrade for all users.
+  - Unless `evaluateViolations` or `check` task is run explicitly, no task will be configured eagerly. 
+  - More info on Gradle: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
+- Removed support for older versions of Ktlint and Detekt
+  - Minimum supported Ktlint Plugin: `6.2.1`
+  - Minimum supported Detekt Plugin: `1.0.0.RC9.2`
+- Fix: In some cases Groovy closures would use wrong scope [PR#185](https://github.com/novoda/gradle-static-analysis-plugin/pull/185)
+- Fix: check task not found on empty project [PR#187](https://github.com/novoda/gradle-static-analysis-plugin/pull/187)
+- Detekt is automatically configured to disable failFast since failure is handled by Static Analysis Plugin [PR#186](https://github.com/novoda/gradle-static-analysis-plugin/pull/186)
+- Update sample with new versions and make use of task configuration avoidance [PR#188](https://github.com/novoda/gradle-static-analysis-plugin/pull/188)
+
 [Version 0.8.1](https://github.com/novoda/gradle-static-analysis-plugin/releases/tag/v0.8.1)
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A Gradle plugin to easily apply the same setup of static analysis tools across different Android, Java or Kotlin projects.
 
+Supports [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) so that you have zero overhead in build speeds when you use this plugin!
+
 ## Description
 Gradle supports many popular static analysis (Checkstyle, PMD, FindBugs, etc) via a set of built-in plugins.
 Using these plugins in an Android module will require an additional setup to compensate for the differences between
@@ -17,15 +19,24 @@ The `gradle-static-analysis-plugin` aims to provide:
 ### Supported tools
 The plugin supports various static analysis tools for Java, Kotlin and Android projects:
 
- * [`Checkstyle`](https://checkstyle.sourceforge.net)
- * [`PMD`](https://pmd.github.io)
- * [`FindBugs`](http://findbugs.sourceforge.net/)
- * [`Detekt`](https://github.com/arturbosch/detekt)
- * [`Android Lint`](https://developer.android.com/studio/write/lint.html)
- * [`KtLint`](https://github.com/shyiko/ktlint)
+ * [`Checkstyle`](docs/tools/checkstyle.md)
+ * [`PMD`](docs/tools/pmd.md)
+ * [`FindBugs`](docs/tools/findbugs.md)
+ * [`Detekt`](docs/tools/detekt.md)
+ * [`Android Lint`](docs/tools/android_lint.md)
+ * [`KtLint`](docs/tools/ktlint.md)
  
 Please note that the tools availability depends on the project the plugin is applied to. For more details please refer to the
 [supported tools](docs/supported-tools.md) page.
+
+### Tools in-consideration
+                          
+ * `Spotbugs` [#142](https://github.com/novoda/gradle-static-analysis-plugin/issues/142)
+ * `CPD (Duplicate Code Detection) ` [#150](https://github.com/novoda/gradle-static-analysis-plugin/iss (Duplicate Code Detection) ues/150)
+ * `error-prone` [#151](https://github.com/novoda/gradle-static-analysis-plugin/issues/151)
+ * `Jetbrains IDEA Inspections` [#152](https://github.com/novoda/gradle-static-analysis-plugin/issues/152)
+
+For all tools in consideration, please refer to [issues](https://github.com/novoda/gradle-static-analysis-plugin/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+tool%22). 
 
 ### Out-of-the-box support for Android projects
 Android projects use a Gradle model that is not compatible with the Java one, supported by the built-in static analysis tools plugins.

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,7 +2,7 @@ ext {
     websiteUrl = 'https://github.com/novoda/gradle-static-analysis-plugin'
 }
 
-version = '0.8.1'
+version = '1.0'
 groovydoc.docTitle = 'Static Analysis Plugin'
 
 apply plugin: 'com.novoda.build-properties'


### PR DESCRIPTION
## Scope of the PR

Prepare release 1.0

I thought it would be cool to do 1.0 now since the project is pretty solid and has 100% task configuration avoidance support. 

## Considerations and implementation
- Updated `CHANGELOG`
- Bumped version for release
- Updated `README`
  - Links in README now point to our docs. Those docs already have links to external project pages. So it makes sense to keep the main page internal for easier navigation.
