### PR TITLE
Update release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gradle static analysis plugin
-[![](https://ci.novoda.com/buildStatus/icon?job=gradle-static-analysis-plugin)](https://ci.novoda.com/job/gradle-static-analysis-plugin/lastSuccessfulBuild) [![](https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-static-analysis-plugin/images/download.svg)](https://bintray.com/novoda/maven/gradle-static-analysis-plugin/_latestVersion)
+[![](https://ci.novoda.com/buildStatus/icon?job=gradle-static-analysis-plugin)](https://ci.novoda.com/job/gradle-static-analysis-plugin/lastSuccessfulBuild) [![](https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-static-analysis-plugin/images/download.svg)](https://bintray.com/novoda-oss/maven/gradle-static-analysis-plugin/_latestVersion)
 
 A Gradle plugin to easily apply the same setup of static analysis tools across different Android, Java or Kotlin projects.
 
@@ -92,19 +92,19 @@ This will enable all the tools with their default settings. For more advanced co
 There are two sample Android projects available, one consisting of a regular app - available [here](https://github.com/novoda/gradle-static-analysis-plugin/tree/master/sample) - and the other comprising a multi-module setup available [here](https://github.com/novoda/gradle-static-analysis-plugin/tree/master/sample-multi-module). Both sample projects showcase a setup featuring Checkstyle, FindBugs, PMD, Lint and Detekt.
 
 ## Snapshots
-[![CI status](https://ci.novoda.com/buildStatus/icon?job=gradle-static-analysis-plugin-snapshot)](https://ci.novoda.com/job/gradle-static-analysis-plugin-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/gradle-static-analysis-plugin/images/download.svg)](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion)
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=gradle-static-analysis-plugin-snapshot)](https://ci.novoda.com/job/gradle-static-analysis-plugin-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda-oss/snapshots/gradle-static-analysis-plugin/images/download.svg)](https://bintray.com/novoda-oss/snapshots-oss/gradle-static-analysis-plugin/_latestVersion)
 
-Snapshot builds from [`develop`](https://github.com/novoda/gradle-static-analysis-plugin/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion) that is not synced with JCenter.
+Snapshot builds from [`develop`](https://github.com/novoda/gradle-static-analysis-plugin/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda-oss/snapshots/gradle-static-analysis-plugin/_latestVersion) that is not synced with JCenter.
 To consume a snapshot build add an additional maven repo as follows:
 ```
 repositories {
     maven {
-        url 'https://novoda.bintray.com/snapshots'
+        url 'https://dl.bintray.com/novoda-oss/snapshots/'
     }
 }
 ```
 
-You can find the latest snapshot version following this [link](https://bintray.com/novoda/snapshots/gradle-static-analysis-plugin/_latestVersion).
+You can find the latest snapshot version following this [link](https://bintray.com/novoda-oss/snapshots/gradle-static-analysis-plugin/_latestVersion).
 
 ## Roadmap
 The plugin is under active development and to be considered in **beta stage**. It is routinely used by many Novoda projects and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,4 +8,4 @@
 1. Execute the [build job](https://ci.novoda.com/job/gradle-static-analysis-plugin/) manually with `BINTRAY_DRY_RUN=false`.
 1. After the release is successful do a manual [github release](https://github.com/novoda/gradle-static-analysis-plugin/releases) with the newly created tag. 
 
-This releases the plugin to [bintray](https://bintray.com/novoda/maven/gradle-static-analysis-plugin) and the [Gradle Plugins Repository](https://plugins.gradle.org/plugin/com.novoda.static-analysis).
+This releases the plugin to [bintray](https://bintray.com/novoda-oss/maven/gradle-static-analysis-plugin) and the [Gradle Plugins Repository](https://plugins.gradle.org/plugin/com.novoda.static-analysis).

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -53,8 +53,8 @@ publish {
     desc = 'Easy setup of static analysis tools for Android and Java projects.'
     publishVersion = buildVersion
 
-    repoName = project.buildProperties.publish['bintrayRepo'].string
-    userOrg = project.buildProperties.publish['bintrayOrg'].string
+    repoName = project.buildProperties.bintray['bintrayRepo'].string
+    userOrg = project.buildProperties.bintray['bintrayOrg'].string
     bintrayUser = project.buildProperties.bintray['bintrayUser'].string
     bintrayKey = project.buildProperties.bintray['bintrayKey'].string
     website = project.websiteUrl

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -16,10 +16,10 @@ buildProperties {
         using rootProject.file('secrets.properties')
         description = '''
     This file should contain:
-- git.username: the username used to push to the repo
-- git.password: the password used to push to the repo
-- gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
-- gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
+        - git.username: the username used to push to the repo
+        - git.password: the password used to push to the repo
+        - gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
+        - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
 		'''
     }
 
@@ -30,14 +30,15 @@ buildProperties {
     bintray {
         def bintrayCredentials = {
             return isDryRun() ?
-                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
                     new File("${System.getenv('BINTRAY_PROPERTIES')}")
         }
         using(bintrayCredentials()).or(cli)
         description = '''This should contain the following properties:
-                         - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
-                         - bintrayUser: name of the account used to deploy the artifacts
-                         - bintrayKey: API key of the account used to deploy the artifacts'''.stripIndent()
+                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                        - bintrayUser: name of the account used to deploy the artifacts
+                        - bintrayKey: API key of the account used to deploy the artifacts'''.stripIndent()
     }
 
 }
@@ -46,13 +47,13 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.novoda.bintray-release'
 
 publish {
-    userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-static-analysis-plugin'
     desc = 'Easy setup of static analysis tools for Android and Java projects.'
     publishVersion = buildVersion
 
-    repoName = project.buildProperties.bintray['bintrayRepo'].string
+    repoName = project.buildProperties.publish['bintrayRepo'].string
+    userOrg = project.buildProperties.publish['bintrayOrg'].string
     bintrayUser = project.buildProperties.bintray['bintrayUser'].string
     bintrayKey = project.buildProperties.bintray['bintrayKey'].string
     website = project.websiteUrl
@@ -200,7 +201,7 @@ boolean isSnapshot() {
 }
 
 String getBuildVersion() {
-    return isSnapshot() ? "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
+    return isSnapshot() ? "DEVELOP-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
 }
 
 String getTag() {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -14,13 +14,13 @@ buildProperties {
 
     secrets {
         using rootProject.file('secrets.properties')
-        description = '''
-    This file should contain:
-        - git.username: the username used to push to the repo
-        - git.password: the password used to push to the repo
-        - gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
-        - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository
-		'''
+        description = '''This file should contain:
+                        - git.username: the username used to push to the repo
+                        - git.password: the password used to push to the repo
+                        - gradle.publish.key: the key to publish the plugin to the Gradle Plugins Repository
+                        - gradle.publish.secret: the secret to publish the plugin to the Gradle Plugins Repository'''
+                .stripIndent()
+
     }
 
     cli {
@@ -38,7 +38,8 @@ buildProperties {
                         - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
                         - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
                         - bintrayUser: name of the account used to deploy the artifacts
-                        - bintrayKey: API key of the account used to deploy the artifacts'''.stripIndent()
+                        - bintrayKey: API key of the account used to deploy the artifacts'''
+                .stripIndent()
     }
 
 }


### PR DESCRIPTION
We are using a different Bintray account to host our OSS projects. These changes allow to inject the `bintrayOrg` property at build time, provided by the CI job through a secret property file.