### PR TITLE
Fix kapt issue

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -2,14 +2,13 @@ package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
-import com.novoda.staticanalysis.internal.CollectViolationsTask
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
 import org.gradle.api.tasks.SourceSet
@@ -99,7 +98,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     private FileCollection getAndroidClasses(javaCompile, List<String> includes) {
-        includes.isEmpty() ? project.files() : project.fileTree(javaCompile.destinationDir).include(includes) as ConfigurableFileTree
+        includes.isEmpty() ? project.files() : project.fileTree(javaCompile.destinationDir).include(includes) as FileCollection
     }
 
     @Override
@@ -140,10 +139,10 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     }
 
     private FileCollection createClassesTreeFrom(SourceSet sourceSet, List<String> includes) {
-        return sourceSet.output.classesDirs.inject(null) { ConfigurableFileTree cumulativeTree, File classesDir ->
+        return sourceSet.output.classesDirs.inject(null) { FileTree cumulativeTree, File classesDir ->
             def tree = project.fileTree(classesDir)
                     .builtBy(sourceSet.output)
-                    .include(includes) as ConfigurableFileTree
+                    .include(includes) as FileCollection
             cumulativeTree?.plus(tree) ?: tree
         }
     }

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurationTest.groovy
@@ -1,0 +1,52 @@
+package com.novoda.staticanalysis.internal.checkstyle
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized.class)
+class CheckstyleConfigurationTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    static Iterable<TestProjectRule> rules() {
+        return [
+                TestProjectRule.forJavaProject(),
+                TestProjectRule.forKotlinProject(),
+                TestProjectRule.forAndroidProject(),
+                TestProjectRule.forAndroidKotlinProject(),
+        ]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    CheckstyleConfigurationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    void shouldConfigureSuccessFully() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withToolsConfig("checkstyle { }")
+                .build('check', '--dry-run')
+    }
+
+    @Test
+    void shouldNotFailBuildWhenCheckstyleIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withToolsConfig("""  
+                    checkstyle {
+                        configFile new File('${Fixtures.Checkstyle.MODULES.path}') 
+                    }
+                    checkstyle {
+                        ignoreFailures = false
+                    }  
+                """)
+                .build('check', '--dry-run')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
@@ -229,22 +229,6 @@ public class CheckstyleIntegrationTest {
                 result.buildFileUrl('reports/checkstyle/main.html'))
     }
 
-    @Test
-    void shouldNotFailBuildWhenCheckstyleIsConfiguredMultipleTimes() {
-        projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withPenalty('none')
-                .withToolsConfig("""  
-                    checkstyle {
-                        configFile new File('${Fixtures.Checkstyle.MODULES.path}') 
-                    }
-                    checkstyle {
-                        ignoreFailures = false
-                    }  
-                """)
-                .build('check', '--dry-run')
-    }
-
     private static String checkstyle(String configFile, String... configs) {
         """checkstyle {
             ${configFile}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurationTest.groovy
@@ -1,0 +1,52 @@
+package com.novoda.staticanalysis.internal.findbugs
+
+
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION
+
+@RunWith(Parameterized.class)
+class FindbugsConfigurationTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    static Iterable<TestProjectRule> rules() {
+        return [
+                TestProjectRule.forJavaProject(),
+                TestProjectRule.forKotlinProject(),
+                TestProjectRule.forAndroidProject(),
+                TestProjectRule.forAndroidKotlinProject(),
+        ]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    FindbugsConfigurationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    void shouldConfigureSuccessFully() {
+        projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withToolsConfig("findbugs { }")
+                .build('check', '--dry-run')
+    }
+
+    @Test
+    void shouldNotFailBuildWhenFindbugsIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withToolsConfig("""
+                    findbugs { }
+                    findbugs {
+                        ignoreFailures = false
+                    }
+                """)
+                .build('check', '--dry-run')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -347,20 +347,6 @@ class FindbugsIntegrationTest {
     }
 
     @Test
-    void shouldNotFailBuildWhenFindbugsIsConfiguredMultipleTimes() {
-        projectRule.newProject()
-                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
-                .withPenalty('none')
-                .withToolsConfig("""
-                    findbugs { }
-                    findbugs {
-                        ignoreFailures = false
-                    }
-                """)
-                .build('check')
-    }
-
-    @Test
     void shouldBeUpToDateWhenCheckTaskRunsAgain() {
         def project = projectRule.newProject()
                 .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
@@ -395,7 +381,7 @@ class FindbugsIntegrationTest {
      * The custom task created in the snippet below will check whether {@code Findbugs} tasks with
      * empty {@code source} will have empty {@code classes} too. </p>
      */
-    private String addCheckFindbugsClassesTask() {
+    private static String addCheckFindbugsClassesTask() {
         '''
         project.task('checkFindbugsClasses') {
             dependsOn project.tasks.findByName('evaluateViolations')

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurationTest.groovy
@@ -1,0 +1,51 @@
+package com.novoda.staticanalysis.internal.pmd
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized.class)
+class PmdConfigurationTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    static Iterable<TestProjectRule> rules() {
+        return [
+                TestProjectRule.forJavaProject(),
+                TestProjectRule.forKotlinProject(),
+                TestProjectRule.forAndroidProject(),
+                TestProjectRule.forAndroidKotlinProject(),
+        ]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    PmdConfigurationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    void shouldConfigureSuccessFully() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withToolsConfig("pmd { }")
+                .build('check', '--dry-run')
+    }
+
+    @Test
+    void shouldNotFailBuildWhenPmdIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withToolsConfig("""  
+                    pmd {
+                    }
+                    pmd {
+                        ignoreFailures = false
+                    }  
+                """)
+                .build('check', '--dry-run')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
@@ -213,22 +213,6 @@ public class PmdIntegrationTest {
         assertThat(result.logs).doesNotContainPmdViolations()
     }
 
-    @Test
-    void shouldNotFailBuildWhenPmdIsConfiguredMultipleTimes() {
-        projectRule.newProject()
-                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
-                .withPenalty('none')
-                .withToolsConfig("""  
-                    pmd {
-                        ruleSetFiles = $DEFAULT_RULES
-                    }
-                    pmd {
-                        ignoreFailures = false
-                    }  
-                """)
-                .build('check')
-    }
-
     private String pmd(String rules, String... configs) {
         """pmd {
             ruleSetFiles = $rules

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/spotbugs/SpotBugsConfigurationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/spotbugs/SpotBugsConfigurationTest.groovy
@@ -1,0 +1,55 @@
+package com.novoda.staticanalysis.internal.spotbugs
+
+
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION
+
+@RunWith(Parameterized.class)
+class SpotBugsConfigurationTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    static Iterable<TestProjectRule> rules() {
+        return [
+                TestProjectRule.forJavaProject(),
+                TestProjectRule.forKotlinProject(),
+                TestProjectRule.forAndroidProject(),
+                TestProjectRule.forAndroidKotlinProject(),
+        ]
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    SpotBugsConfigurationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    void shouldConfigureSuccessFully() {
+        projectRule.newProject()
+                .withPlugin('com.github.spotbugs', "2.0.0")
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withToolsConfig("spotbugs { }")
+                .build('check', '--dry-run')
+    }
+
+    @Test
+    void shouldNotFailBuildWhenSpotBugsIsConfiguredMultipleTimes() {
+        projectRule.newProject()
+                .withPlugin('com.github.spotbugs', "2.0.0")
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
+                .withPenalty('none')
+                .withToolsConfig("""
+                    spotbugs { }
+                    spotbugs {
+                        effort = "max"
+                    }
+                """)
+                .build('check', '--dry-run')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/spotbugs/SpotBugsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/spotbugs/SpotBugsIntegrationTest.groovy
@@ -144,20 +144,6 @@ class SpotBugsIntegrationTest {
     }
 
     @Test
-    void shouldNotFailBuildWhenSpotBugsIsConfiguredMultipleTimes() {
-        createProjectWith()
-                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION)
-                .withPenalty('none')
-                .withToolsConfig("""
-                    spotbugs { }
-                    spotbugs {
-                        effort = "max"
-                    }
-                """)
-                .build('check')
-    }
-
-    @Test
     void shouldBeUpToDateWhenCheckTaskRunsAgain() {
         def project = createProjectWith()
                 .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -23,6 +23,7 @@ repositories {
 }
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt' // adding kapt since we face compat issues before
 apply plugin: 'com.novoda.static-analysis'
 
 android {

--- a/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
@@ -19,6 +19,7 @@ plugins {
 }
 
 apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt' // adding kapt since we face compat issues before
 apply plugin: 'com.novoda.static-analysis'
 
 repositories { 

--- a/sample-multi-module/core/build.gradle
+++ b/sample-multi-module/core/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
 
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+dependencies {                
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 compileKotlin {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.novoda.static-analysis'
 


### PR DESCRIPTION
Use Simple FileTree/FileCollection instead of ConfigurableFileTree

We were never dependant on that particular class and it seems like applying other plugins change the implementation class.

## Tests

Also added tests to first reproduce it and then fix it.

For this, created new suite of tests for java-only plugins to also include Kotlin projects and test configuration. 

Fixes #199