### PR TITLE
Deprecate findbugs

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -12,16 +12,19 @@ import org.gradle.api.file.FileTree
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsExtension
 import org.gradle.api.tasks.SourceSet
+import org.gradle.util.DeprecationLogger
 
 import java.nio.file.Path
 
 import static com.novoda.staticanalysis.internal.TasksCompat.configureNamed
 import static com.novoda.staticanalysis.internal.TasksCompat.createTask
 
+@Deprecated
 class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExtension> {
 
     protected boolean htmlReportEnabled = true
 
+    @Deprecated
     static FindbugsConfigurator create(Project project,
                                        NamedDomainObjectContainer<Violations> violationsContainer,
                                        Task evaluateViolations) {
@@ -66,6 +69,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
     @Override
     protected void configureAndroidWithVariants(DomainObjectSet variants) {
         if (configured) return
+        logDeprecatedMessage()
 
         variants.all { configureVariant(it) }
         variantFilter.filteredTestVariants.all { configureVariant(it) }
@@ -103,6 +107,9 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     @Override
     protected void configureJavaProject() {
+        if (!configured) {
+            logDeprecatedMessage()
+        }
         super.configureJavaProject()
         project.afterEvaluate {
             project.sourceSets.each { SourceSet sourceSet ->
@@ -172,7 +179,6 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
         }
     }
 
-
     private void createHtmlReportTask(String taskName) {
         createTask(project, "generate${taskName.capitalize()}HtmlReport", GenerateFindBugsHtmlReport) { GenerateFindBugsHtmlReport task ->
             def findbugs = project.tasks[taskName] as FindBugs
@@ -185,5 +191,14 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     private def getAndroidJar() {
         "${project.android.sdkDirectory}/platforms/${project.android.compileSdkVersion}/android.jar"
+    }
+
+    private def logDeprecatedMessage() {
+        DeprecationLogger.nagUserWith(
+                "Novoda Static Analysis Plugin Findbugs support is deprecated.",
+                "This is scheduled to be removed in version 2.0",
+                "Please use SpotBugs instead. https://github.com/novoda/gradle-static-analysis-plugin/blob/master/docs/tools/spotbugs.md",
+                null
+        )
     }
 }


### PR DESCRIPTION
Depreacte Findbugs support since it is completely removed in Gradle 6.x. After this is merged, I will prepare new release with docs update to make it obvious in the Readme.

Used Gradle's official deprecation support. When run with `--warning-mode all`, it looks like this. First is output by Gradle, the 2nd by us.

```
The findbugs plugin has been deprecated. This is scheduled to be removed in Gradle 6.0. Consider using the com.github.spotbugs plugin instead.
        at static_analysis_2u2ywn09w7g7lt00gz4re3daa$_run_closure1.doCall(/Users/sdane/dev/taso/gradle-static-analysis-plugin/sample-multi-module/team-props/static-analysis.gradle:25)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Novoda Static Analysis Plugin Findbugs support is deprecated. This is scheduled to be removed in version 2.0 Please use SpotBugs instead. https://github.com/novoda/gradle-static-analysis-plugin/blob/master/docs/tools/spotbugs.md
        at static_analysis_2u2ywn09w7g7lt00gz4re3daa$_run_closure1.doCall(/Users/sdane/dev/taso/gradle-static-analysis-plugin/sample-multi-module/team-props/static-analysis.gradle:25)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```