### PR TITLE
Fix Gradle 6 issue

### DIFF
--- a/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -3,7 +3,7 @@ package com.novoda.staticanalysis
 import com.novoda.staticanalysis.internal.Configurator
 import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
 import com.novoda.staticanalysis.internal.detekt.DetektConfigurator
-import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator
+import com.novoda.staticanalysis.internal.findbugs.FindbugsConfiguratorFactory
 import com.novoda.staticanalysis.internal.ktlint.KtlintConfigurator
 import com.novoda.staticanalysis.internal.lint.LintConfigurator
 import com.novoda.staticanalysis.internal.pmd.PmdConfigurator
@@ -42,7 +42,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
         [
                 CheckstyleConfigurator.create(project, violationsContainer, evaluateViolations),
                 PmdConfigurator.create(project, violationsContainer, evaluateViolations),
-                FindbugsConfigurator.create(project, violationsContainer, evaluateViolations),
+                FindbugsConfiguratorFactory.create(project, violationsContainer, evaluateViolations),
                 SpotBugsConfigurator.create(project, violationsContainer, evaluateViolations),
                 DetektConfigurator.create(project, violationsContainer, evaluateViolations),
                 KtlintConfigurator.create(project, violationsContainer, evaluateViolations),

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -4,7 +4,6 @@ import com.novoda.staticanalysis.Violations
 import com.novoda.staticanalysis.internal.CodeQualityConfigurator
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectSet
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -24,17 +23,7 @@ class FindbugsConfigurator extends CodeQualityConfigurator<FindBugs, FindBugsExt
 
     protected boolean htmlReportEnabled = true
 
-    @Deprecated
-    static FindbugsConfigurator create(Project project,
-                                       NamedDomainObjectContainer<Violations> violationsContainer,
-                                       Task evaluateViolations) {
-        Violations violations = violationsContainer.maybeCreate('Findbugs')
-        return new FindbugsConfigurator(project, violations, evaluateViolations)
-    }
-
-    private FindbugsConfigurator(Project project,
-                                 Violations violations,
-                                 Task evaluateViolations) {
+    FindbugsConfigurator(Project project, Violations violations, Task evaluateViolations) {
         super(project, violations, evaluateViolations)
     }
 

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfiguratorFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfiguratorFactory.groovy
@@ -1,0 +1,20 @@
+package com.novoda.staticanalysis.internal.findbugs
+
+import com.novoda.staticanalysis.Violations
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+@Deprecated
+class FindbugsConfiguratorFactory {
+
+    private FindbugsConfiguratorFactory() {
+    }
+
+    static FindbugsConfigurator create(Project project,
+                                       NamedDomainObjectContainer<Violations> violationsContainer,
+                                       Task evaluateViolations) {
+        Violations violations = violationsContainer.maybeCreate('Findbugs')
+        return new FindbugsConfigurator(project, violations, evaluateViolations)
+    }
+}


### PR DESCRIPTION
Gradle loads classes with all its dependencies. So FindbugsConfigurator.create would fail on Gradle 6. Guarding it in a separate Factory class solves the issue

Fixes #204 