### PR TITLE
Add tests for new detekt versions.

### DIFF
--- a/docs/tools/detekt.md
+++ b/docs/tools/detekt.md
@@ -4,7 +4,7 @@ does not support Java. It can be used in both pure Kotlin, and Android Kotlin pr
 have Kotlin code in your project. The plugin only runs Detekt on projects that contain the Kotlin or the Kotlin-Android plugin.
 
 > Supported Detekt Gradle Plugin version: **1.0.0.RC9.2 and above** 
-> Recommended Detekt Gradle Plugin version: **1.0.0-RC14 and above** 
+> Last tested Detekt Gradle Plugin version: **1.3.1**
 
 ## Table of contents
  * [IMPORTANT: setup Detekt](#important-setup-detekt)

--- a/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/staticanalysis/internal/detekt/DetektConfigurator.groovy
@@ -18,7 +18,7 @@ class DetektConfigurator implements Configurator {
     private static final String DETEKT_NOT_APPLIED = 'The Detekt plugin is configured but not applied. Please apply the plugin in your build script.\nFor more information see https://github.com/arturbosch/detekt.'
     private static final String XML_REPORT_NOT_ENABLED = 'XML report must be enabled. Please make sure to enable "reports.xml" in your Detekt configuration'
 
-    private static final String LAST_COMPATIBLE_DETEKT_VERSION = '1.0.0-RC14'
+    private static final String LAST_COMPATIBLE_DETEKT_VERSION = '1.3.1'
     private static final String MIN_COMPATIBLE_DETEKT_VERSION = '1.0.0.RC9.2' // Do not forget to update detekt.md
     private static final String DETEKT_CONFIGURATION_ERROR = """\
 A problem occurred while configuring Detekt. Please make sure to use a compatible version:

--- a/plugin/src/test/fixtures/rules/detekt/detekt.yml
+++ b/plugin/src/test/fixtures/rules/detekt/detekt.yml
@@ -1,27 +1,4 @@
-autoCorrect: true
-failFast: false
-
-test-pattern: # Configure exclusions for test sources
-  active: true
-  patterns: # Test file regexes
-    - '.*/test/.*'
-    - '.*Test.kt'
-    - '.*Spec.kt'
-  exclude-rule-sets:
-     - 'comments'
-  exclude-rules:
-    - 'NamingRules'
-    - 'WildcardImport'
-    - 'MagicNumber'
-    - 'MaxLineLength'
-    - 'LateinitUsage'
-    - 'StringLiteralDuplication'
-    - 'SpreadOperator'
-    - 'TooManyFunctions'
-
 build:
-  warningThreshold: 5
-  failThreshold: 10
   weights:
     complexity: 2
     formatting: 1
@@ -33,12 +10,6 @@ processors:
 
 console-reports:
   active: false
-
-output-reports:
-  active: true
-  exclude:
-  #  - 'PlainOutputReport'
-  #  - 'XmlOutputReport'
 
 comments:
   active: true
@@ -158,23 +129,8 @@ exceptions:
     active: false
   TooGenericExceptionCaught:
     active: true
-    exceptions:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
   TooGenericExceptionThrown:
     active: true
-    exceptions:
-     - Error
-     - Exception
-     - NullPointerException
-     - Throwable
-     - RuntimeException
 
 naming:
   active: true
@@ -312,8 +268,6 @@ style:
     active: true
   OptionalAbstractKeyword:
     active: true
-  OptionalReturnKeyword:
-    active: false
   OptionalUnit:
     active: false
   OptionalWhenBraces:

--- a/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/staticanalysis/internal/detekt/DetektIntegrationTest.groovy
@@ -21,17 +21,14 @@ class DetektIntegrationTest {
         return [
                 [TestProjectRule.forKotlinProject(), "1.0.0.RC9.2"],
                 [TestProjectRule.forAndroidKotlinProject(), "1.0.0.RC9.2"],
-                [TestProjectRule.forKotlinProject(), "1.0.0-RC10"],
-                [TestProjectRule.forAndroidKotlinProject(), "1.0.0-RC10"],
-                [TestProjectRule.forKotlinProject(), "1.0.0-RC11"],
-                [TestProjectRule.forAndroidKotlinProject(), "1.0.0-RC11"],
-                [TestProjectRule.forKotlinProject(), "1.0.0-RC12"],
-                [TestProjectRule.forAndroidKotlinProject(), "1.0.0-RC12"],
-                // Work fine but requires Gradle 5.x to run
-                // [TestProjectRule.forKotlinProject(), "1.0.0-RC13"],
-                // [TestProjectRule.forAndroidKotlinProject(), "1.0.0-RC13"],
-                // [TestProjectRule.forKotlinProject(), "1.0.0-RC14"],
-                // [TestProjectRule.forAndroidKotlinProject(), "1.0.0-RC14"],
+                [TestProjectRule.forKotlinProject(), "1.0.1"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.0.1"],
+                [TestProjectRule.forKotlinProject(), "1.1.1"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.1.1"],
+                [TestProjectRule.forKotlinProject(), "1.2.2"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.2.2"],
+                [TestProjectRule.forKotlinProject(), "1.3.1"],
+                [TestProjectRule.forAndroidKotlinProject(), "1.3.1"],
         ]*.toArray()
     }
 

--- a/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestAndroidKotlinProject.groovy
@@ -42,7 +42,12 @@ android {
         ${formatSourceSets(project)}
     }
     ${project.additionalAndroidConfig}
+}         
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
 }
+
 ${formatExtension(project)}
 """
     }

--- a/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
+++ b/plugin/src/test/groovy/com/novoda/test/TestKotlinProject.groovy
@@ -26,6 +26,10 @@ repositories {
     jcenter()
 }
 
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
+}
+
 sourceSets {
     ${formatSourceSets(project)}
 }


### PR DESCRIPTION
Add tests for new detekt versions.

- Remove intermediate and old versions. Keep only the min supported version.
- Update detekt.yml to remove deprecated configs
- Fix kotlin configuration issue by adding the stdlib dependency